### PR TITLE
Add workflow to add backport 2.x label automatically when PR opened

### DIFF
--- a/.github/workflows/add-backport-label.yml
+++ b/.github/workflows/add-backport-label.yml
@@ -1,0 +1,15 @@
+name: Add Backport Label
+on:
+  pull_request_target:
+    branches: main
+    types: opened
+
+jobs:
+  add_labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-ecosystem/action-add-labels@v1
+        with:
+          labels: backport 2.x
+

--- a/.github/workflows/add-backport-label.yml
+++ b/.github/workflows/add-backport-label.yml
@@ -12,4 +12,3 @@ jobs:
       - uses: actions-ecosystem/action-add-labels@v1
         with:
           labels: backport 2.x
-

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,7 +7,15 @@ on:
 
 jobs:
   backport:
-    if: ${{ contains(github.event.label.name, 'backport') }}
+    if: >
+      github.event.pull_request.merged
+      && (
+        github.event.action == 'closed'
+        || (
+          github.event.action == 'labeled'
+          && contains(github.event.label.name, 'backport')
+        )
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
### Description

I've pushed a `2.x` branch.  It is identical to the `main` branch except for the OpenSearch version in build.gradle.

To keep the 2.x branch up-to-date we need to backport (almost) every future commit to `main` (except things that apply to `main` only, like this action!).  To ease that process, this workflow automatically adds the `backport 2.x` label to every new PR.  Remove it if you don't need it.

Action reference: https://github.com/actions-ecosystem/action-add-labels?tab=readme-ov-file#add-a-single-label-with-a-comment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
