### PR TITLE
Actually define the snapshot repo so we can publish to it

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -189,6 +189,21 @@ subprojects {
                 }
             }
         }
+
+        repositories {
+            maven {
+                name = 'staging'
+                url = "${rootProject.buildDir}/local-staging-repo"
+            }
+            maven {
+                name = "Snapshots"
+                url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+                credentials {
+                    username "$System.env.SONATYPE_USERNAME"
+                    password "$System.env.SONATYPE_PASSWORD"
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### Description

Fixes build.gradle to supply the snapshot repo information.

### Issues Resolved

Fixes failing snapshot publication workflow.  When this PR is merged, we should (hopefully) get our first snapshot uploaded.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
