### PR TITLE
Switch publication to shadow JAR and add build script

### DIFF
--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -34,4 +34,4 @@ jobs:
           export SONATYPE_PASSWORD=$(aws secretsmanager get-secret-value --secret-id maven-snapshots-password --query SecretString --output text)
           echo "::add-mask::$SONATYPE_USERNAME"
           echo "::add-mask::$SONATYPE_PASSWORD"
-          ./gradlew publishMavenJavaPublicationToSnapshotsRepository
+          ./gradlew publishShadowPublicationToSnapshotsRepository

--- a/aos-client/build.gradle
+++ b/aos-client/build.gradle
@@ -32,3 +32,14 @@ dependencies {
     implementation("software.amazon.awssdk:url-connection-client")
     implementation("software.amazon.awssdk:utils")
 }
+
+shadowJar {
+    dependsOn(':opensearch-remote-metadata-sdk-core:shadowJar', 
+              ':opensearch-remote-metadata-sdk-remote-client:shadowJar')
+    from(project(':opensearch-remote-metadata-sdk-core').shadowJar.outputs.files) {
+        into 'META-INF/lib'
+    }
+    from(project(':opensearch-remote-metadata-sdk-remote-client').shadowJar.outputs.files) {
+        into 'META-INF/lib'
+    }
+}

--- a/aos-client/build.gradle
+++ b/aos-client/build.gradle
@@ -36,10 +36,4 @@ dependencies {
 shadowJar {
     dependsOn(':opensearch-remote-metadata-sdk-core:shadowJar', 
               ':opensearch-remote-metadata-sdk-remote-client:shadowJar')
-    from(project(':opensearch-remote-metadata-sdk-core').shadowJar.outputs.files) {
-        into 'META-INF/lib'
-    }
-    from(project(':opensearch-remote-metadata-sdk-remote-client').shadowJar.outputs.files) {
-        into 'META-INF/lib'
-    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -141,7 +141,7 @@ subprojects {
 
     shadowJar {
         archiveClassifier.set(null)
-        from sourceSets.main.output
+        mergeServiceFiles()
     }
 
     checkstyle {

--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ allprojects {
 
 subprojects {
     apply plugin: 'java-library'
+    apply plugin: 'com.github.johnrengelman.shadow'
 
     dependencies {
         // Common dependencies for all subprojects
@@ -98,6 +99,8 @@ subprojects {
 
     configurations {
         testImplementation.extendsFrom testFixtures
+        implementation.extendsFrom shadowImplementation
+        runtimeOnly.extendsFrom shadowRuntimeOnly
     }
 
     test {
@@ -136,6 +139,11 @@ subprojects {
         withJavadocJar()
     }
 
+    shadowJar {
+        archiveClassifier.set(null)
+        from sourceSets.main.output
+    }
+
     checkstyle {
         toolVersion = "10.21.1"
     }
@@ -147,17 +155,25 @@ subprojects {
 
     publishing {
         publications {
-            mavenJava(MavenPublication) {
+            shadow(MavenPublication) {
                 from components.java
 
-                // These are for unpublished test classes
-                suppressPomMetadataWarningsFor('testFixturesApiElements')
-                suppressPomMetadataWarningsFor('testFixturesRuntimeElements')
+                project.shadow.component(it)
 
                 // Customize artifact ID for core project
                 if (project.name == 'opensearch-remote-metadata-sdk-core') {
                     artifactId = 'opensearch-remote-metadata-sdk'
                 }
+
+                artifacts.clear()
+
+                artifact shadowJar
+                artifact sourcesJar
+                artifact javadocJar
+
+                // These are for unpublished test classes
+                suppressPomMetadataWarningsFor('testFixturesApiElements')
+                suppressPomMetadataWarningsFor('testFixturesRuntimeElements')
 
                 pom {
                     name = project.name == 'opensearch-remote-metadata-sdk-core'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -16,5 +16,3 @@ java {
 dependencies {
     testFixturesImplementation "org.opensearch:opensearch:${opensearch_version}"
 }
-
-

--- a/ddb-client/build.gradle
+++ b/ddb-client/build.gradle
@@ -12,3 +12,18 @@ dependencies {
     implementation(platform("software.amazon.awssdk:bom:${aws_sdk_version}"))
     implementation "software.amazon.awssdk:dynamodb"
 }
+
+shadowJar {
+    dependsOn(':opensearch-remote-metadata-sdk-core:shadowJar', 
+              ':opensearch-remote-metadata-sdk-remote-client:shadowJar',
+              ':opensearch-remote-metadata-sdk-aos-client:shadowJar')
+    from(project(':opensearch-remote-metadata-sdk-core').shadowJar.outputs.files) {
+        into 'META-INF/lib'
+    }
+    from(project(':opensearch-remote-metadata-sdk-remote-client').shadowJar.outputs.files) {
+        into 'META-INF/lib'
+    }
+    from(project(':opensearch-remote-metadata-sdk-aos-client').shadowJar.outputs.files) {
+        into 'META-INF/lib'
+    }
+}

--- a/ddb-client/build.gradle
+++ b/ddb-client/build.gradle
@@ -17,13 +17,4 @@ shadowJar {
     dependsOn(':opensearch-remote-metadata-sdk-core:shadowJar', 
               ':opensearch-remote-metadata-sdk-remote-client:shadowJar',
               ':opensearch-remote-metadata-sdk-aos-client:shadowJar')
-    from(project(':opensearch-remote-metadata-sdk-core').shadowJar.outputs.files) {
-        into 'META-INF/lib'
-    }
-    from(project(':opensearch-remote-metadata-sdk-remote-client').shadowJar.outputs.files) {
-        into 'META-INF/lib'
-    }
-    from(project(':opensearch-remote-metadata-sdk-aos-client').shadowJar.outputs.files) {
-        into 'META-INF/lib'
-    }
 }

--- a/remote-client/build.gradle
+++ b/remote-client/build.gradle
@@ -9,3 +9,10 @@ dependencies {
 
     implementation "org.opensearch.client:opensearch-java:${opensearch_java_version}"
 }
+
+shadowJar {
+    dependsOn(':opensearch-remote-metadata-sdk-core:shadowJar')
+    from(project(':opensearch-remote-metadata-sdk-core').shadowJar.outputs.files) {
+        into 'META-INF/lib'
+    }
+}

--- a/remote-client/build.gradle
+++ b/remote-client/build.gradle
@@ -12,7 +12,4 @@ dependencies {
 
 shadowJar {
     dependsOn(':opensearch-remote-metadata-sdk-core:shadowJar')
-    from(project(':opensearch-remote-metadata-sdk-core').shadowJar.outputs.files) {
-        into 'META-INF/lib'
-    }
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Copyright OpenSearch Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+set -ex
+
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-q QUALIFIER\t[Optional] Version qualifier."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-p PLATFORM\t[Optional] Platform, ignored."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
+    echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-h help"
+}
+
+while getopts ":h:v:q:s:o:p:a:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        q)
+            QUALIFIER=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        p)
+            PLATFORM=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: You must specify the OpenSearch version"
+    usage
+    exit 1
+fi
+
+[[ ! -z "$QUALIFIER" ]] && VERSION=$VERSION-$QUALIFIER
+[[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+
+./gradlew build -x test -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+./gradlew publishShadowPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+./gradlew publishShadowPublicationToStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+mkdir -p $OUTPUT/maven/org/opensearch
+cp -r ./build/local-staging-repo/org/opensearch/. $OUTPUT/maven/org/opensearch


### PR DESCRIPTION
### Description

Changes publication to a shadow jar.

Adds a build.sh script as part of onboarding per https://github.com/opensearch-project/opensearch-build/blob/main/ONBOARDING.md#onboard-to-build-workflow

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
