### PR TITLE
Build on JDK 11 on 2.x branch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,6 +46,7 @@ jobs:
       matrix:
         java:
           - 11
+          - 17
           - 21
           - 23
     name: Linux JDK ${{ matrix.java }}
@@ -86,6 +87,7 @@ jobs:
       matrix:
         java:
           - 11
+          - 17
           - 21
           - 23
     name: Windows JDK ${{ matrix.java }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: 17
           distribution: temurin
       - name: Spotless Check
         run: ./gradlew spotlessCheck
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: 21
+          java-version: 11
           distribution: temurin
       - name: Javadoc CheckStyle
         run: ./gradlew checkstyleMain
@@ -45,6 +45,7 @@ jobs:
     strategy:
       matrix:
         java:
+          - 11
           - 21
           - 23
     name: Linux JDK ${{ matrix.java }}
@@ -84,6 +85,7 @@ jobs:
     strategy:
       matrix:
         java:
+          - 11
           - 21
           - 23
     name: Windows JDK ${{ matrix.java }}

--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 21
+          java-version: 11
       - uses: actions/checkout@v4
       - uses: aws-actions/configure-aws-credentials@v4.0.2
         with:

--- a/build.gradle
+++ b/build.gradle
@@ -67,8 +67,8 @@ allprojects {
     }
 
     java {
-        targetCompatibility = JavaVersion.VERSION_21
-        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_11
         withSourcesJar()
         withJavadocJar()
     }


### PR DESCRIPTION
### Description

Updates workflows on 2.x branch to use JDK 11.

Note spotless needs JDK17+ and is run separately.

### Issues Resolved

https://github.com/opensearch-project/ml-commons/actions/runs/12714319588/job/35444132691?pr=3366


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
