### PR TITLE
Use latest version of checkstyle to avoid Guava CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,14 @@ buildscript {
     }
 }
 
+plugins {
+    id 'checkstyle'
+}
+
+checkstyle {
+    toolVersion = "latest.release"
+}
+
 allprojects {
     apply plugin: 'java'
     apply plugin: 'idea'
@@ -49,7 +57,6 @@ allprojects {
     apply plugin: 'eclipse'
     apply plugin: 'jacoco'
     apply plugin: 'com.diffplug.spotless'
-    apply plugin: 'checkstyle'
 
     repositories {
         mavenLocal()


### PR DESCRIPTION
### Description

Checkstyle 9.3 is CVE-impacted.  Directs gradle to use latest version to avoid this.

### Issues Resolved

Fixes #4 (again)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
