### PR TITLE
choosing jackson version from core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import org.opensearch.gradle.VersionProperties
+
 buildscript {
     ext {
         opensearch_group = "org.opensearch"
@@ -21,7 +23,6 @@ buildscript {
 
         opensearch_java_version = '2.19.0'
         log4j_version = '2.24.3'
-        jackson_version = '2.18.2'
         apache_http_components_version = '5.4.1'
         apache_http_core_version = '5.3.2'
         aws_sdk_version = '2.29.50'
@@ -79,6 +80,7 @@ allprojects {
         withSourcesJar()
         withJavadocJar()
     }
+    project.getExtensions().getExtraProperties().set("versions", VersionProperties.getVersions())
 }
 
 subprojects {
@@ -91,10 +93,10 @@ subprojects {
         implementation "org.apache.logging.log4j:log4j-api:${log4j_version}"
         implementation "org.apache.logging.log4j:log4j-core:${log4j_version}"
 
-        implementation "com.fasterxml.jackson.core:jackson-databind:${jackson_version}"
-        implementation "com.fasterxml.jackson.core:jackson-core:${jackson_version}"
-        implementation "com.fasterxml.jackson.core:jackson-annotations:${jackson_version}"
-        implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jackson_version}"
+        implementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
+        implementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
+        implementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson_databind}"
+        implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson_databind}"
 
         implementation "org.apache.httpcomponents.client5:httpclient5:${apache_http_components_version}"
         implementation "org.apache.httpcomponents.core5:httpcore5:${apache_http_core_version}"


### PR DESCRIPTION
### Description

In ML-Commons, I'm facing:

```
> Task :opensearch-ml-plugin:run FAILED
Exec output and error:
| Output for ./bin/opensearch-plugin:-> Installing file:/Volumes/workplace/ml-commons/plugin/build/distributions/opensearch-ml-3.0.0.0-SNAPSHOT.zip
| -> Downloading file:/Volumes/workplace/ml-commons/plugin/build/distributions/opensearch-ml-3.0.0.0-SNAPSHOT.zip
| -> Failed installing file:/Volumes/workplace/ml-commons/plugin/build/distributions/opensearch-ml-3.0.0.0-SNAPSHOT.zip
| -> Rolling back file:/Volumes/workplace/ml-commons/plugin/build/distributions/opensearch-ml-3.0.0.0-SNAPSHOT.zip
| -> Rolled back file:/Volumes/workplace/ml-commons/plugin/build/distributions/opensearch-ml-3.0.0.0-SNAPSHOT.zip
| Exception in thread "main" java.lang.IllegalStateException: failed to load plugin opensearch-ml due to jar hell
|       at org.opensearch.plugins.PluginsService.checkBundleJarHell(PluginsService.java:702)
|       at org.opensearch.plugins.InstallPluginCommand.jarHellCheck(InstallPluginCommand.java:839)
|       at org.opensearch.plugins.InstallPluginCommand.loadPluginInfo(InstallPluginCommand.java:807)
|       at org.opensearch.plugins.InstallPluginCommand.installPlugin(InstallPluginCommand.java:852)
|       at org.opensearch.plugins.InstallPluginCommand.execute(InstallPluginCommand.java:274)
|       at org.opensearch.plugins.InstallPluginCommand.execute(InstallPluginCommand.java:248)
|       at org.opensearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:104)
|       at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
|       at org.opensearch.cli.MultiCommand.execute(MultiCommand.java:104)
|       at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
|       at org.opensearch.cli.Command.main(Command.java:101)
|       at org.opensearch.plugins.PluginCli.main(PluginCli.java:66)
| Caused by: java.lang.IllegalStateException: jar hell!
| class: com.fasterxml.jackson.databind.AbstractTypeResolver
| jar1: /Volumes/workplace/ml-commons/plugin/build/testclusters/integTest-0/distro/3.0.0-ARCHIVE/plugins/.installing-12768717337776440255/jackson-databind-2.18.2.jar
| jar2: /Volumes/workplace/ml-commons/plugin/build/testclusters/integTest-0/distro/3.0.0-ARCHIVE/plugins/.installing-12768717337776440255/opensearch-remote-metadata-sdk-3.0.0-SNAPSHOT.jar
|       at org.opensearch.bootstrap.JarHell.checkClass(JarHell.java:316)
|       at org.opensearch.bootstrap.JarHell.checkJarHell(JarHell.java:215)
|       at org.opensearch.plugins.PluginsService.checkBundleJarHell(PluginsService.java:688)
|       ... 11 more
[Incubating] Problems report is available at: file:///Volumes/workplace/ml-commons/build/reports/problems/problems-report.html

FAILURE: Build failed with an exception.
```

I think we can have the same jackson library what we consume from snapshot.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
