### PR TITLE
Change dependencies to compileOnly to keep out of shadow jar

### DIFF
--- a/aos-client/build.gradle
+++ b/aos-client/build.gradle
@@ -4,33 +4,33 @@
  */
 
 dependencies {
-    implementation project(':opensearch-remote-metadata-sdk-core')
+    compileOnly project(':opensearch-remote-metadata-sdk-core')
     testImplementation testFixtures(project(':opensearch-remote-metadata-sdk-core'))
-    implementation project(':opensearch-remote-metadata-sdk-remote-client')
+    compileOnly project(':opensearch-remote-metadata-sdk-remote-client')
 
-    implementation "org.opensearch.client:opensearch-java:${opensearch_java_version}"
+    compileOnly "org.opensearch.client:opensearch-java:${opensearch_java_version}"
 
-    implementation(platform("software.amazon.awssdk:bom:${aws_sdk_version}"))
-    implementation("software.amazon.awssdk:apache-client")
-    implementation("software.amazon.awssdk:sdk-core")
-    implementation("software.amazon.awssdk:aws-core")
-    implementation("software.amazon.awssdk:aws-json-protocol")
-    implementation("software.amazon.awssdk:auth")
-    implementation("software.amazon.awssdk:checksums")
-    implementation("software.amazon.awssdk:checksums-spi")
-    implementation("software.amazon.awssdk:endpoints-spi")
-    implementation("software.amazon.awssdk:http-auth-aws")
-    implementation("software.amazon.awssdk:http-auth-spi")
-    implementation("software.amazon.awssdk:http-client-spi")
-    implementation("software.amazon.awssdk:identity-spi")
-    implementation("software.amazon.awssdk:json-utils")
-    implementation("software.amazon.awssdk:metrics-spi")
-    implementation("software.amazon.awssdk:profiles")
-    implementation("software.amazon.awssdk:protocol-core")
-    implementation("software.amazon.awssdk:regions")
-    implementation("software.amazon.awssdk:third-party-jackson-core")
-    implementation("software.amazon.awssdk:url-connection-client")
-    implementation("software.amazon.awssdk:utils")
+    compileOnly(platform("software.amazon.awssdk:bom:${aws_sdk_version}"))
+    compileOnly("software.amazon.awssdk:apache-client")
+    compileOnly("software.amazon.awssdk:sdk-core")
+    compileOnly("software.amazon.awssdk:aws-core")
+    compileOnly("software.amazon.awssdk:aws-json-protocol")
+    compileOnly("software.amazon.awssdk:auth")
+    compileOnly("software.amazon.awssdk:checksums")
+    compileOnly("software.amazon.awssdk:checksums-spi")
+    compileOnly("software.amazon.awssdk:endpoints-spi")
+    compileOnly("software.amazon.awssdk:http-auth-aws")
+    compileOnly("software.amazon.awssdk:http-auth-spi")
+    compileOnly("software.amazon.awssdk:http-client-spi")
+    compileOnly("software.amazon.awssdk:identity-spi")
+    compileOnly("software.amazon.awssdk:json-utils")
+    compileOnly("software.amazon.awssdk:metrics-spi")
+    compileOnly("software.amazon.awssdk:profiles")
+    compileOnly("software.amazon.awssdk:protocol-core")
+    compileOnly("software.amazon.awssdk:regions")
+    compileOnly("software.amazon.awssdk:third-party-jackson-core")
+    compileOnly("software.amazon.awssdk:url-connection-client")
+    compileOnly("software.amazon.awssdk:utils")
 }
 
 shadowJar {

--- a/build.gradle
+++ b/build.gradle
@@ -87,27 +87,26 @@ subprojects {
 
     dependencies {
         // Common dependencies for all subprojects
-        implementation "org.opensearch:opensearch:${opensearch_version}"
-        implementation "org.apache.logging.log4j:log4j-api:${log4j_version}"
-        implementation "org.apache.logging.log4j:log4j-core:${log4j_version}"
+        compileOnly "org.opensearch:opensearch:${opensearch_version}"
+        compileOnly "org.apache.logging.log4j:log4j-api:${log4j_version}"
+        compileOnly "org.apache.logging.log4j:log4j-core:${log4j_version}"
 
-        implementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}")
-        implementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
-        implementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson_databind}"
-        implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson_databind}"
+        compileOnly "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
+        compileOnly "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
+        compileOnly "com.fasterxml.jackson.core:jackson-core:${versions.jackson_databind}"
+        compileOnly "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson_databind}"
 
-        implementation "org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}"
-        implementation "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}"
+        compileOnly "org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}"
+        compileOnly "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}"
 
         testImplementation "org.opensearch.test:framework:${opensearch_version}"
         testImplementation "org.junit.jupiter:junit-jupiter:${junit_version}"
         testImplementation "org.mockito:mockito-core:${mockito_version}"
+        testImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson_databind}"
     }
 
     configurations {
         testImplementation.extendsFrom testFixtures
-        implementation.extendsFrom shadowImplementation
-        runtimeOnly.extendsFrom shadowRuntimeOnly
     }
 
     test {

--- a/ddb-client/build.gradle
+++ b/ddb-client/build.gradle
@@ -4,13 +4,13 @@
  */
 
 dependencies {
-    implementation project(':opensearch-remote-metadata-sdk-core')
+    compileOnly project(':opensearch-remote-metadata-sdk-core')
     testImplementation testFixtures(project(':opensearch-remote-metadata-sdk-core'))
-    implementation project(':opensearch-remote-metadata-sdk-remote-client')
-    implementation project(':opensearch-remote-metadata-sdk-aos-client')
+    compileOnly project(':opensearch-remote-metadata-sdk-remote-client')
+    compileOnly project(':opensearch-remote-metadata-sdk-aos-client')
 
-    implementation(platform("software.amazon.awssdk:bom:${aws_sdk_version}"))
-    implementation "software.amazon.awssdk:dynamodb"
+    compileOnly(platform("software.amazon.awssdk:bom:${aws_sdk_version}"))
+    compileOnly "software.amazon.awssdk:dynamodb"
 }
 
 shadowJar {

--- a/remote-client/build.gradle
+++ b/remote-client/build.gradle
@@ -4,10 +4,10 @@
  */
 
 dependencies {
-    implementation project(':opensearch-remote-metadata-sdk-core')
+    compileOnly project(':opensearch-remote-metadata-sdk-core')
     testImplementation testFixtures(project(':opensearch-remote-metadata-sdk-core'))
 
-    implementation "org.opensearch.client:opensearch-java:${opensearch_java_version}"
+    compileOnly "org.opensearch.client:opensearch-java:${opensearch_java_version}"
 }
 
 shadowJar {


### PR DESCRIPTION
### Description

`s/implementation/compileOnly/g`

### Issues Resolved

Lets downstream library users not get jar hell

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
