### PR TITLE
Add build script to onboard to OpenSearch release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         build_version_qualifier = System.getProperty("build.version_qualifier", "")
 
         version_tokens = opensearch_version.tokenize('-')
-        opensearch_build = version_tokens[0]
+        opensearch_build = version_tokens[0] + '.0'
         if (build_version_qualifier) {
             opensearch_build += "-${build_version_qualifier}"
         }

--- a/formatter/formatting.gradle
+++ b/formatter/formatting.gradle
@@ -34,7 +34,7 @@ spotless {
 
         trimTrailingWhitespace()
         endWithNewline()
-        indentWithSpaces()
+        leadingTabsToSpaces()
     }
     format("license", {
         licenseHeaderFile("${rootProject.file("formatter/license-header.txt")}", "package ");

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# Copyright OpenSearch Contributors.
+# SPDX-License-Identifier: Apache-2.0
+
+set -ex
+
+function usage() {
+    echo "Usage: $0 [args]"
+    echo ""
+    echo "Arguments:"
+    echo -e "-v VERSION\t[Required] OpenSearch version."
+    echo -e "-q QUALIFIER\t[Optional] Version qualifier."
+    echo -e "-s SNAPSHOT\t[Optional] Build a snapshot, default is 'false'."
+    echo -e "-p PLATFORM\t[Optional] Platform, ignored."
+    echo -e "-a ARCHITECTURE\t[Optional] Build architecture, ignored."
+    echo -e "-o OUTPUT\t[Optional] Output path, default is 'artifacts'."
+    echo -e "-h help"
+}
+
+while getopts ":h:v:q:s:o:p:a:" arg; do
+    case $arg in
+        h)
+            usage
+            exit 1
+            ;;
+        v)
+            VERSION=$OPTARG
+            ;;
+        q)
+            QUALIFIER=$OPTARG
+            ;;
+        s)
+            SNAPSHOT=$OPTARG
+            ;;
+        o)
+            OUTPUT=$OPTARG
+            ;;
+        p)
+            PLATFORM=$OPTARG
+            ;;
+        a)
+            ARCHITECTURE=$OPTARG
+            ;;
+        :)
+            echo "Error: -${OPTARG} requires an argument"
+            usage
+            exit 1
+            ;;
+        ?)
+            echo "Invalid option: -${arg}"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$VERSION" ]; then
+    echo "Error: You must specify the OpenSearch version"
+    usage
+    exit 1
+fi
+
+[[ ! -z "$QUALIFIER" ]] && VERSION=$VERSION-$QUALIFIER
+[[ "$SNAPSHOT" == "true" ]] && VERSION=$VERSION-SNAPSHOT
+[ -z "$OUTPUT" ] && OUTPUT=artifacts
+
+./gradlew build -x test -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+./gradlew publishMavenJavaPublicationToMavenLocal -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+./gradlew publishMavenJavaPublicationToStagingRepository -Dopensearch.version=$VERSION -Dbuild.snapshot=$SNAPSHOT -Dbuild.version_qualifier=$QUALIFIER
+mkdir -p $OUTPUT/maven/org/opensearch
+cp -r ./build/local-staging-repo/org/opensearch/. $OUTPUT/maven/org/opensearch
+


### PR DESCRIPTION
### Description

Adds a build.sh script as part of onboarding per https://github.com/opensearch-project/opensearch-build/blob/main/ONBOARDING.md#onboard-to-build-workflow

Resubmission of #29 without doing shadow jar publication 

Also adds a fourth digit to the version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
