### PR TITLE
Allow specifying a default Executor when instantiating SdkClient

### DIFF
--- a/core/src/main/java/org/opensearch/remote/metadata/client/SdkClient.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/SdkClient.java
@@ -26,15 +26,27 @@ import static org.opensearch.remote.metadata.common.SdkClientUtils.unwrapAndConv
 public class SdkClient {
 
     private final SdkClientDelegate delegate;
+    private final Executor defaultExecutor;
     private final Boolean isMultiTenancyEnabled;
 
     /**
-     * Instantiate this client
+     * Instantiate this client with the {@link ForkJoinPool#commonPool()} as the default executor
      * @param delegate The client implementation to delegate calls to
      * @param multiTenancy whether multiTenancy is enabled
      */
     public SdkClient(SdkClientDelegate delegate, Boolean multiTenancy) {
+        this(delegate, ForkJoinPool.commonPool(), multiTenancy);
+    }
+
+    /**
+     * Instantiate this client with a default Executor
+     * @param delegate The client implementation to delegate calls to
+     * @param defaultExecutor A default executor to use for asynchronous execution unless otherwise specified
+     * @param multiTenancy whether multiTenancy is enabled
+     */
+    public SdkClient(SdkClientDelegate delegate, Executor defaultExecutor, Boolean multiTenancy) {
         this.delegate = delegate;
+        this.defaultExecutor = defaultExecutor;
         this.isMultiTenancyEnabled = multiTenancy;
     }
 
@@ -50,12 +62,12 @@ public class SdkClient {
     }
 
     /**
-     * Create/Put/Index a data object/document into a table/index.
+     * Create/Put/Index a data object/document into a table/index using the default executor.
      * @param request A request encapsulating the data object to store
      * @return A completion stage encapsulating the response or exception
      */
     public CompletionStage<PutDataObjectResponse> putDataObjectAsync(PutDataObjectRequest request) {
-        return putDataObjectAsync(request, ForkJoinPool.commonPool());
+        return putDataObjectAsync(request, defaultExecutor);
     }
 
     /**
@@ -72,7 +84,7 @@ public class SdkClient {
     }
 
     /**
-     * Read/Get a data object/document from a table/index.
+     * Read/Get a data object/document from a table/index using the default executor.
      *
      * @param request  A request identifying the data object to retrieve
      * @param executor the executor to use for asynchronous execution
@@ -90,7 +102,7 @@ public class SdkClient {
      */
     public CompletionStage<GetDataObjectResponse> getDataObjectAsync(GetDataObjectRequest request) {
         validateTenantId(request.tenantId());
-        return getDataObjectAsync(request, ForkJoinPool.commonPool());
+        return getDataObjectAsync(request, defaultExecutor);
     }
 
     /**
@@ -119,13 +131,13 @@ public class SdkClient {
     }
 
     /**
-     * Update a data object/document in a table/index.
+     * Update a data object/document in a table/index using the default executor.
      *
      * @param request A request identifying the data object to update
      * @return A completion stage encapsulating the response or exception
      */
     public CompletionStage<UpdateDataObjectResponse> updateDataObjectAsync(UpdateDataObjectRequest request) {
-        return updateDataObjectAsync(request, ForkJoinPool.commonPool());
+        return updateDataObjectAsync(request, defaultExecutor);
     }
 
     /**
@@ -154,13 +166,13 @@ public class SdkClient {
     }
 
     /**
-     * Delete a data object/document from a table/index.
+     * Delete a data object/document from a table/index using the default executor.
      *
      * @param request A request identifying the data object to delete
      * @return A completion stage encapsulating the response or exception
      */
     public CompletionStage<DeleteDataObjectResponse> deleteDataObjectAsync(DeleteDataObjectRequest request) {
-        return deleteDataObjectAsync(request, ForkJoinPool.commonPool());
+        return deleteDataObjectAsync(request, defaultExecutor);
     }
 
     /**
@@ -189,13 +201,13 @@ public class SdkClient {
     }
 
     /**
-     * Perform a bulk request for multiple data objects/documents in potentially multiple tables/indices.
+     * Perform a bulk request for multiple data objects/documents in potentially multiple tables/indices using the default executor.
      *
      * @param request A request identifying the bulk requests to execute
      * @return A completion stage encapsulating the response or exception
      */
     public CompletionStage<BulkDataObjectResponse> bulkDataObjectAsync(BulkDataObjectRequest request) {
-        return bulkDataObjectAsync(request, ForkJoinPool.commonPool());
+        return bulkDataObjectAsync(request, defaultExecutor);
     }
 
     /**
@@ -225,13 +237,13 @@ public class SdkClient {
     }
 
     /**
-     * Search for data objects/documents in a table/index.
+     * Search for data objects/documents in a table/index using the default executor.
      *
      * @param request A request identifying the data objects to search for
      * @return A completion stage encapsulating the response or exception
      */
     public CompletionStage<SearchDataObjectResponse> searchDataObjectAsync(SearchDataObjectRequest request) {
-        return searchDataObjectAsync(request, ForkJoinPool.commonPool());
+        return searchDataObjectAsync(request, defaultExecutor);
     }
 
     /**

--- a/core/src/main/java/org/opensearch/remote/metadata/client/impl/SdkClientFactory.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/impl/SdkClientFactory.java
@@ -19,6 +19,8 @@ import org.opensearch.remote.metadata.client.SdkClientDelegate;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.ServiceLoader;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
 
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_TYPE_KEY;
 import static org.opensearch.remote.metadata.common.CommonValue.TENANT_AWARE_KEY;
@@ -34,9 +36,26 @@ public class SdkClientFactory {
      * @param client The OpenSearch node client used as the default implementation
      * @param xContentRegistry The OpenSearch XContentRegistry
      * @param metadataSettings A map defining the remote metadata type and configuration
-     * @return An instance of SdkClient which delegates to an implementation based on Remote Metadata Type
+     * @return An instance of SdkClient which delegates to an implementation based on Remote Metadata Type. The {@link ForkJoinPool#commonPool()} will be used by default for async execution.
      */
     public static SdkClient createSdkClient(Client client, NamedXContentRegistry xContentRegistry, Map<String, String> metadataSettings) {
+        return createSdkClient(client, xContentRegistry, metadataSettings, ForkJoinPool.commonPool());
+    }
+
+    /**
+     * Create a new SdkClient with implementation determined by the value of the Remote Metadata Type setting
+     * @param client The OpenSearch node client used as the default implementation
+     * @param xContentRegistry The OpenSearch XContentRegistry
+     * @param metadataSettings A map defining the remote metadata type and configuration
+     * @param defaultExecutor The default executor to use if another one is not specified
+     * @return An instance of SdkClient which delegates to an implementation based on Remote Metadata Type
+     */
+    public static SdkClient createSdkClient(
+        Client client,
+        NamedXContentRegistry xContentRegistry,
+        Map<String, String> metadataSettings,
+        Executor defaultExecutor
+    ) {
         String remoteMetadataType = metadataSettings.get(REMOTE_METADATA_TYPE_KEY);
         Boolean multiTenancy = Boolean.parseBoolean(metadataSettings.get(TENANT_AWARE_KEY));
 
@@ -46,7 +65,7 @@ public class SdkClientFactory {
         if (Strings.isNullOrEmpty(remoteMetadataType)) {
             // Default client does not use SPI
             log.info("Using local opensearch cluster as metadata store.", remoteMetadataType);
-            return createDefaultClient(client, xContentRegistry, metadataSettings, multiTenancy);
+            return createDefaultClient(client, xContentRegistry, metadataSettings, defaultExecutor, multiTenancy);
         } else {
             // Use SPI to find the correct client
             while (iterator.hasNext()) {
@@ -54,24 +73,25 @@ public class SdkClientFactory {
                 if (delegate.supportsMetadataType(remoteMetadataType)) {
                     log.info("Using {} as metadata store.", remoteMetadataType);
                     delegate.initialize(metadataSettings);
-                    return new SdkClient(delegate, multiTenancy);
+                    return new SdkClient(delegate, defaultExecutor, multiTenancy);
                 }
             }
         }
 
         // If no suitable implementation is found, use the default
         log.warn("Unable to find {} client implementation. Using local opensearch cluster as metadata store.", remoteMetadataType);
-        return createDefaultClient(client, xContentRegistry, metadataSettings, multiTenancy);
+        return createDefaultClient(client, xContentRegistry, metadataSettings, defaultExecutor, multiTenancy);
     }
 
     private static SdkClient createDefaultClient(
         Client client,
         NamedXContentRegistry xContentRegistry,
         Map<String, String> metadataSettings,
+        Executor defaultExecutor,
         Boolean multiTenancy
     ) {
         LocalClusterIndicesClient defaultclient = new LocalClusterIndicesClient(client, xContentRegistry, metadataSettings);
-        return new SdkClient(defaultclient, multiTenancy);
+        return new SdkClient(defaultclient, defaultExecutor, multiTenancy);
     }
 
     // Package private for testing


### PR DESCRIPTION
### Description

Allows an optional extra argument when creating the `SdkClient` that changes the default executor (when a specific one isn't supplied) from `ForkJoinPool.commonPool()` to the specified one.

This will allow us to replace all the specific `fooDataObjectAsync()` calls and remove the executor parameter if we set the default executor to `client.threadPool().executor(ThreadPool.Names.SAME)`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
