### PR TITLE
Move codecov upload to its own GHA job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,23 @@ jobs:
         run: ./gradlew checkstyleMain
       - name: Javadoc Check
         run: ./gradlew javadoc
-
+  codecov:
+    if: github.repository == 'opensearch-project/opensearch-remote-metadata-sdk'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: temurin
+      - name: Run Tests
+        run: ./gradlew test
+      - name: Upload Coverage Report
+        uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          file: ./build/reports/jacoco/test/jacocoTestReport.xml
   build-linux:
     needs: [Get-CI-Image-Tag, spotless, javadoc]
     strategy:
@@ -71,14 +87,6 @@ jobs:
         su `id -un 1000` -c 'whoami && java -version &&
                              echo "build and run tests" && ./gradlew build &&
                              echo "Publish to Maven Local" && ./gradlew publishToMavenLocal'
-    - name: Upload Coverage Report
-      if: contains(matrix.java, '21')
-      uses: codecov/codecov-action@v5
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      with:
-        file: ./build/reports/jacoco/test/jacocoTestReport.xml
-
   build-windows:
     needs: [spotless, javadoc]
     strategy:


### PR DESCRIPTION
### Description

Moves the codecov upload out to its own CI job.  
 - Since it only requires `test` task it will run even if integ tests fail
 - The current location using the CI image is failing upload due to glibc version, see https://github.com/opensearch-project/opensearch-build/issues/5226 (scheduled to be fixed in 2.19.0 but moving it is still a good idea per first bullet)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
