### PR TITLE
Fix codecov upload for codecov-action v5

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,8 +7,6 @@ on:
   pull_request:
     branches:
       - "*"
-env:
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   Get-CI-Image-Tag:
@@ -71,13 +69,32 @@ jobs:
         su `id -un 1000` -c 'whoami && java -version &&
                              echo "build and run tests" && ./gradlew build &&
                              echo "Publish to Maven Local" && ./gradlew publishToMavenLocal'
-    - name: Upload Coverage Report
+    - name: Upload Coverage Report Artifacts
       if: contains(matrix.java, '21')
-      uses: codecov/codecov-action@v5
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      uses: actions/upload-artifact@v4
       with:
-        file: ./build/reports/jacoco/test/jacocoTestReport.xml
+        name: coverage-report-linux-jdk${{ matrix.java }}
+        path: '**/build/reports/jacoco/test/jacocoTestReport.xml'
+
+  linux-codecov-upload:
+    needs: build-linux
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download Coverage Report Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-report-linux-jdk21
+          path: ./coverage-reports
+      - name: Find Coverage Reports
+        id: find-jacoco-reports
+        run: |
+          REPORTS=$(find ./coverage-reports -name "jacocoTestReport.xml" | tr '\n' ',' | sed 's/,$//')
+          echo "report_files=$REPORTS" >> $GITHUB_OUTPUT
+      - name: Upload Coverage Report
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ${{ steps.find-jacoco-reports.outputs.report_files }}
 
   build-windows:
     needs: [spotless, javadoc]


### PR DESCRIPTION
### Description

The action to upload code coverage changed parameter name in v5 from `file` to `files`.

### Issues Resolved

> Warning: Unexpected input(s) 'file', valid inputs are ['base_sha', 'binary', 'codecov_yml_path', 'commit_parent', 'directory', 'disable_file_fixes', 'disable_search', 'disable_safe_directory', 'disable_telem', 'dry_run', 'env_vars', 'exclude', 'fail_ci_if_error', 'files', 'flags', 'force', 'git_service', 'gcov_args', 'gcov_executable', 'gcov_ignore', 'gcov_include', 'handle_no_reports_found', 'job_code', 'name', 'network_filter', 'network_prefix', 'os', 'override_branch', 'override_build', 'override_build_url', 'override_commit', 'override_pr', 'plugins', 'report_code', 'report_type', 'root_dir', 'run_command', 'skip_validation', 'slug', 'swift_project', 'token', 'url', 'use_legacy_upload_endpoint', 'use_oidc', 'use_pypi', 'verbose', 'version', 'working-directory']

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
