### PR TITLE
Update o.o.client imports to o.o.transport.client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ All notable changes to this project are documented in this file.
 
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
+## [Unreleased 3.0](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/compare/2.x...HEAD)
+### Features
+### Enhancements
+### Bug Fixes
+### Infrastructure
+### Documentation
+### Maintenance
+### Refactoring
+- Update o.o.client imports to o.o.transport.client ([#73](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/73))
+
 ## [Unreleased 2.x](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/compare/2.19...2.x)
 ### Features
 ### Enhancements

--- a/aos-client/src/test/java/org/opensearch/remote/metadata/client/impl/AOSSdkClientFactoryTests.java
+++ b/aos-client/src/test/java/org/opensearch/remote/metadata/client/impl/AOSSdkClientFactoryTests.java
@@ -9,10 +9,10 @@
 package org.opensearch.remote.metadata.client.impl;
 
 import org.opensearch.OpenSearchException;
-import org.opensearch.client.Client;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.remote.metadata.common.TestClassLoader;
+import org.opensearch.transport.client.Client;
 import org.junit.AfterClass;
 import org.junit.jupiter.api.Test;
 

--- a/core/src/main/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClient.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClient.java
@@ -20,7 +20,6 @@ import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.update.UpdateRequest;
-import org.opensearch.client.Client;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.Strings;
@@ -53,6 +52,7 @@ import org.opensearch.remote.metadata.client.SearchDataObjectResponse;
 import org.opensearch.remote.metadata.client.UpdateDataObjectRequest;
 import org.opensearch.remote.metadata.client.UpdateDataObjectResponse;
 import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.transport.client.Client;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/core/src/main/java/org/opensearch/remote/metadata/client/impl/SdkClientFactory.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/impl/SdkClientFactory.java
@@ -10,11 +10,11 @@ package org.opensearch.remote.metadata.client.impl;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.client.Client;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.remote.metadata.client.SdkClientDelegate;
+import org.opensearch.transport.client.Client;
 
 import java.util.Iterator;
 import java.util.Map;

--- a/core/src/test/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClientTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClientTests.java
@@ -28,7 +28,6 @@ import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.action.support.replication.ReplicationResponse.ShardInfo;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.update.UpdateResponse;
-import org.opensearch.client.Client;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentType;
@@ -58,6 +57,7 @@ import org.opensearch.remote.metadata.client.UpdateDataObjectResponse;
 import org.opensearch.remote.metadata.common.TestDataObject;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.internal.InternalSearchResponse;
+import org.opensearch.transport.client.Client;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/core/src/test/java/org/opensearch/remote/metadata/client/impl/SdkClientFactoryTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/impl/SdkClientFactoryTests.java
@@ -8,10 +8,10 @@
  */
 package org.opensearch.remote.metadata.client.impl;
 
-import org.opensearch.client.Client;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.remote.metadata.common.TestClassLoader;
+import org.opensearch.transport.client.Client;
 import org.junit.AfterClass;
 import org.junit.jupiter.api.Test;
 

--- a/ddb-client/src/test/java/org/opensearch/remote/metadata/client/impl/DDBSdkClientFactoryTests.java
+++ b/ddb-client/src/test/java/org/opensearch/remote/metadata/client/impl/DDBSdkClientFactoryTests.java
@@ -9,10 +9,10 @@
 package org.opensearch.remote.metadata.client.impl;
 
 import org.opensearch.OpenSearchException;
-import org.opensearch.client.Client;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.remote.metadata.common.TestClassLoader;
+import org.opensearch.transport.client.Client;
 import org.junit.AfterClass;
 import org.junit.jupiter.api.Test;
 

--- a/remote-client/src/test/java/org/opensearch/remote/metadata/client/impl/RemoteSdkClientFactoryTests.java
+++ b/remote-client/src/test/java/org/opensearch/remote/metadata/client/impl/RemoteSdkClientFactoryTests.java
@@ -9,10 +9,10 @@
 package org.opensearch.remote.metadata.client.impl;
 
 import org.opensearch.OpenSearchException;
-import org.opensearch.client.Client;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.remote.metadata.client.SdkClient;
 import org.opensearch.remote.metadata.common.TestClassLoader;
+import org.opensearch.transport.client.Client;
 import org.junit.AfterClass;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
### Description

Updates the package for `o.o.client.Client` to `o.o.transport.client.Client`

### Issues Resolved

Relates to https://github.com/opensearch-project/OpenSearch/pull/17272

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
