### PR TITLE
Refactor SDKClientUtil for better readability, fix javadocs

### DIFF
--- a/core/src/main/java/org/opensearch/remote/metadata/common/SdkClientUtils.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/common/SdkClientUtils.java
@@ -59,15 +59,15 @@ public class SdkClientUtils {
         Class<? extends Throwable>... exceptionTypesToUnwrap
     ) {
         return (r, throwable) -> {
-            if (throwable == null) {
-                try {
-                    IndexResponse indexResponse = r.parser() == null ? null : IndexResponse.fromXContent(r.parser());
-                    listener.onResponse(indexResponse);
-                } catch (IOException e) {
-                    handleParseFailure(listener, "put");
-                }
-            } else {
+            if (throwable != null) {
                 handleThrowable(listener, throwable, exceptionTypesToUnwrap);
+                return;
+            }
+            try {
+                IndexResponse indexResponse = r.parser() == null ? null : IndexResponse.fromXContent(r.parser());
+                listener.onResponse(indexResponse);
+            } catch (IOException e) {
+                handleParseFailure(listener, "put");
             }
         };
     }
@@ -76,6 +76,7 @@ public class SdkClientUtils {
      * Wraps the completion of a GET operation from the SdkClient into a format compatible with an ActionListener.
      *
      * @param listener The ActionListener that will receive the parsed GetResponse or any errors
+     * @param exceptionTypesToUnwrap optional list of exception types to unwrap. Defaults to {@link OpenSearchStatusException} and {@link CompletionException}.
      * @return A BiConsumer that can be used directly with CompletionStage's whenComplete method
      */
     @SafeVarargs
@@ -84,15 +85,15 @@ public class SdkClientUtils {
         Class<? extends Throwable>... exceptionTypesToUnwrap
     ) {
         return (r, throwable) -> {
-            if (throwable == null) {
-                try {
-                    GetResponse getResponse = r.parser() == null ? null : GetResponse.fromXContent(r.parser());
-                    listener.onResponse(getResponse);
-                } catch (IOException e) {
-                    handleParseFailure(listener, "get");
-                }
-            } else {
+            if (throwable != null) {
                 handleThrowable(listener, throwable, exceptionTypesToUnwrap);
+                return;
+            }
+            try {
+                GetResponse getResponse = r.parser() == null ? null : GetResponse.fromXContent(r.parser());
+                listener.onResponse(getResponse);
+            } catch (IOException e) {
+                handleParseFailure(listener, "get");
             }
         };
     }
@@ -101,6 +102,7 @@ public class SdkClientUtils {
      * Wraps the completion of an UPDATE operation from the SdkClient into a format compatible with an ActionListener.
      *
      * @param listener The ActionListener that will receive the parsed UpdateResponse or any errors
+     * @param exceptionTypesToUnwrap optional list of exception types to unwrap. Defaults to {@link OpenSearchStatusException} and {@link CompletionException}.
      * @return A BiConsumer that can be used directly with CompletionStage's whenComplete method
      */
     @SafeVarargs
@@ -109,15 +111,15 @@ public class SdkClientUtils {
         Class<? extends Throwable>... exceptionTypesToUnwrap
     ) {
         return (r, throwable) -> {
-            if (throwable == null) {
-                try {
-                    UpdateResponse updateResponse = r.parser() == null ? null : UpdateResponse.fromXContent(r.parser());
-                    listener.onResponse(updateResponse);
-                } catch (IOException e) {
-                    handleParseFailure(listener, "update");
-                }
-            } else {
+            if (throwable != null) {
                 handleThrowable(listener, throwable, exceptionTypesToUnwrap);
+                return;
+            }
+            try {
+                UpdateResponse updateResponse = r.parser() == null ? null : UpdateResponse.fromXContent(r.parser());
+                listener.onResponse(updateResponse);
+            } catch (IOException e) {
+                handleParseFailure(listener, "update");
             }
         };
     }
@@ -126,6 +128,7 @@ public class SdkClientUtils {
      * Wraps the completion of a DELETE operation from the SdkClient into a format compatible with an ActionListener.
      *
      * @param listener The ActionListener that will receive the parsed DeleteResponse or any errors
+     * @param exceptionTypesToUnwrap optional list of exception types to unwrap. Defaults to {@link OpenSearchStatusException} and {@link CompletionException}.
      * @return A BiConsumer that can be used directly with CompletionStage's whenComplete method
      */
     @SafeVarargs
@@ -134,15 +137,15 @@ public class SdkClientUtils {
         Class<? extends Throwable>... exceptionTypesToUnwrap
     ) {
         return (r, throwable) -> {
-            if (throwable == null) {
-                try {
-                    DeleteResponse deleteResponse = r.parser() == null ? null : DeleteResponse.fromXContent(r.parser());
-                    listener.onResponse(deleteResponse);
-                } catch (IOException e) {
-                    handleParseFailure(listener, "delete");
-                }
-            } else {
+            if (throwable != null) {
                 handleThrowable(listener, throwable, exceptionTypesToUnwrap);
+                return;
+            }
+            try {
+                DeleteResponse deleteResponse = r.parser() == null ? null : DeleteResponse.fromXContent(r.parser());
+                listener.onResponse(deleteResponse);
+            } catch (IOException e) {
+                handleParseFailure(listener, "delete");
             }
         };
     }
@@ -151,6 +154,7 @@ public class SdkClientUtils {
      * Wraps the completion of a BULK operation from the SdkClient into a format compatible with an ActionListener.
      *
      * @param listener The ActionListener that will receive the parsed BulkResponse or any errors
+     * @param exceptionTypesToUnwrap optional list of exception types to unwrap. Defaults to {@link OpenSearchStatusException} and {@link CompletionException}.
      * @return A BiConsumer that can be used directly with CompletionStage's whenComplete method
      */
     @SafeVarargs
@@ -159,15 +163,15 @@ public class SdkClientUtils {
         Class<? extends Throwable>... exceptionTypesToUnwrap
     ) {
         return (r, throwable) -> {
-            if (throwable == null) {
-                try {
-                    BulkResponse bulkResponse = r.parser() == null ? null : BulkResponse.fromXContent(r.parser());
-                    listener.onResponse(bulkResponse);
-                } catch (IOException e) {
-                    handleParseFailure(listener, "bulk");
-                }
-            } else {
+            if (throwable != null) {
                 handleThrowable(listener, throwable, exceptionTypesToUnwrap);
+                return;
+            }
+            try {
+                BulkResponse bulkResponse = r.parser() == null ? null : BulkResponse.fromXContent(r.parser());
+                listener.onResponse(bulkResponse);
+            } catch (IOException e) {
+                handleParseFailure(listener, "bulk");
             }
         };
     }
@@ -176,6 +180,7 @@ public class SdkClientUtils {
      * Wraps the completion of a SEARCH operation from the SdkClient into a format compatible with an ActionListener.
      *
      * @param listener The ActionListener that will receive the parsed SearchResponse or any errors
+     * @param exceptionTypesToUnwrap optional list of exception types to unwrap. Defaults to {@link OpenSearchStatusException} and {@link CompletionException}.
      * @return A BiConsumer that can be used directly with CompletionStage's whenComplete method
      */
     @SafeVarargs
@@ -184,15 +189,15 @@ public class SdkClientUtils {
         Class<? extends Throwable>... exceptionTypesToUnwrap
     ) {
         return (r, throwable) -> {
-            if (throwable == null) {
-                try {
-                    SearchResponse searchResponse = r.parser() == null ? null : SearchResponse.fromXContent(r.parser());
-                    listener.onResponse(searchResponse);
-                } catch (IOException e) {
-                    handleParseFailure(listener, "search");
-                }
-            } else {
+            if (throwable != null) {
                 handleThrowable(listener, throwable, exceptionTypesToUnwrap);
+                return;
+            }
+            try {
+                SearchResponse searchResponse = r.parser() == null ? null : SearchResponse.fromXContent(r.parser());
+                listener.onResponse(searchResponse);
+            } catch (IOException e) {
+                handleParseFailure(listener, "search");
             }
         };
     }


### PR DESCRIPTION
### Description

Addresses additional comments from #75 after merging:
 - add missing param javadocs
 - moves exception handling earlier as a fast return, to reduce indentation later.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
