### PR TITLE
[Backport 2.19] Fixes CVE-2025-24970

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Bug Fixes
 - Improve exception unwrapping flexibility for SdkClientUtils ([#67](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/67))
 - Add util methods to handle ActionListeners in whenComplete ([#75](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/75))
--  Refactor SDKClientUtil for better readability, fix javadocs ([#78](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/78))
+- Refactor SDKClientUtil for better readability, fix javadocs ([#78](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/78))
 - Make DynamoDBClient fully async ([#79](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/79))
 ### Infrastructure
 ### Documentation
 ### Maintenance
+- Bump aws sdk to 2.30.18 from 2.29.50 ([#93](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/93))
 ### Refactoring

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
         opensearch_java_version = '2.19.0'
         apache_http_components_version = '5.4.1'
         apache_http_core_version = '5.3.2'
-        aws_sdk_version = '2.29.50'
+        aws_sdk_version = '2.30.18'
         junit_version = '5.11.4' // version catalog is 4.x
     }
 


### PR DESCRIPTION
### Description
Backport of https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/93

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
