### PR TITLE
Fix checkstyle to actually run on subprojects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,14 +40,6 @@ buildscript {
     }
 }
 
-plugins {
-    id 'checkstyle'
-}
-
-checkstyle {
-    toolVersion = "latest.release"
-}
-
 allprojects {
     apply plugin: 'java'
     apply plugin: 'idea'
@@ -55,6 +47,7 @@ allprojects {
     apply plugin: 'eclipse'
     apply plugin: 'jacoco'
     apply plugin: 'com.diffplug.spotless'
+    apply plugin: 'checkstyle'
 
     repositories {
         mavenLocal()
@@ -78,6 +71,11 @@ allprojects {
         withJavadocJar()
     }
     project.getExtensions().getExtraProperties().set("versions", VersionProperties.getVersions())
+
+    checkstyle {
+        toolVersion = "latest.release"
+    }
+
 }
 
 subprojects {


### PR DESCRIPTION
### Description

Checkstyle was running on the main project (doing nothing) with the latest version, and on subprojects using a fixed version.  When I merged #98 to remove the redundant version definition, that also caused Checkstyle to stop running on subprojects.  

Moving the original definition to all projects to restore the intended behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
