### PR TITLE
Update deprecated features in Gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,9 +29,9 @@ buildscript {
 
     repositories {
         mavenLocal()
-        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
+        maven { url = "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
-        maven { url "https://plugins.gradle.org/m2/" }
+        maven { url = "https://plugins.gradle.org/m2/" }
     }
 
     dependencies {
@@ -58,10 +58,10 @@ allprojects {
 
     repositories {
         mavenLocal()
-        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
+        maven { url = "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
-        maven { url "https://plugins.gradle.org/m2/" }
-        maven { url "https://artifacts.opensearch.org/releases/" }
+        maven { url = "https://plugins.gradle.org/m2/" }
+        maven { url = "https://artifacts.opensearch.org/releases/" }
     }
 
     group = opensearch_group
@@ -117,10 +117,10 @@ subprojects {
         outputs.upToDateWhen { false }
         testLogging {
             events "failed", "skipped"
-            showExceptions true
-            showCauses true
-            showStackTraces true
-            exceptionFormat "full"
+            showExceptions = true
+            showCauses = true
+            showStackTraces = true
+            exceptionFormat = "full"
         }
         afterSuite { desc, result ->
             if (!desc.parent) {
@@ -205,8 +205,8 @@ subprojects {
                 name = "Snapshots"
                 url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
                 credentials {
-                    username "$System.env.SONATYPE_USERNAME"
-                    password "$System.env.SONATYPE_PASSWORD"
+                    username = "$System.env.SONATYPE_USERNAME"
+                    password = "$System.env.SONATYPE_PASSWORD"
                 }
             }
         }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -7,14 +7,6 @@ plugins {
     id 'java-test-fixtures'
 }
 
-java {
-    registerFeature('testFixtures') {
-        usingSourceSet(sourceSets.testFixtures)  
-    }
-}
-
 dependencies {
     testFixturesImplementation "org.opensearch:opensearch:${opensearch_version}"
 }
-
-


### PR DESCRIPTION
### Description

Space assignment syntax is deprecated and will be removed in Gradle 10.
 - https://docs.gradle.org/8.12.1/userguide/upgrading_version_8.html#groovy_space_assignment_syntax

Mutating core plugins is deprecated and will be removed in Gradle 9.
 - https://docs.gradle.org/8.12.1/userguide/upgrading_version_8.html#configurations_allowed_usage

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
