### PR TITLE
Fix version conflict check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Enhancements
 ### Bug Fixes
 - Fix version conflict check for update ([#114](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/114))
+
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Features
 ### Enhancements
 ### Bug Fixes
+- Fix version conflict check for update ([#114](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/114))
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/core/src/main/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClient.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClient.java
@@ -10,6 +10,7 @@ package org.opensearch.remote.metadata.client.impl;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.DocWriteRequest.OpType;
 import org.opensearch.action.bulk.BulkItemResponse;
@@ -237,13 +238,14 @@ public class LocalClusterIndicesClient extends AbstractSdkClient {
                         }
                     }
                 }, e -> {
-                    if (e instanceof VersionConflictEngineException) {
+                    Throwable t = ExceptionsHelper.unwrapCause(e);
+                    if (t instanceof VersionConflictEngineException) {
                         log.error("Document version conflict updating {} in {}: {}", request.id(), request.index(), e.getMessage(), e);
                         future.completeExceptionally(
                             new OpenSearchStatusException(
                                 "Document version conflict updating " + request.id() + " in index " + request.index(),
                                 RestStatus.CONFLICT,
-                                e
+                                t
                             )
                         );
                     } else {
@@ -251,7 +253,7 @@ public class LocalClusterIndicesClient extends AbstractSdkClient {
                             new OpenSearchStatusException(
                                 "Failed to update data object in index " + request.index(),
                                 RestStatus.INTERNAL_SERVER_ERROR,
-                                e
+                                t
                             )
                         );
                     }

--- a/core/src/test/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClientTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClientTests.java
@@ -8,7 +8,6 @@
  */
 package org.opensearch.remote.metadata.client.impl;
 
-import org.mockito.Mockito;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.DocWriteRequest.OpType;
 import org.opensearch.action.DocWriteResponse;
@@ -72,9 +71,9 @@ import java.util.stream.Collectors;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-import static org.mockito.Mockito.when;
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.remote.metadata.common.CommonValue.TENANT_ID_FIELD_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -86,6 +85,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class LocalClusterIndicesClientTests {
 
@@ -474,19 +474,18 @@ public class LocalClusterIndicesClientTests {
     @Test
     public void testUpdateDataObject_VersionCheck_unwrap() throws IOException {
         UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest.builder()
-                .index(TEST_INDEX)
-                .id(TEST_ID)
-                .tenantId(TEST_TENANT_ID)
-                .dataObject(testDataObject)
-                .ifSeqNo(5)
-                .ifPrimaryTerm(2)
-                .build();
+            .index(TEST_INDEX)
+            .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
+            .dataObject(testDataObject)
+            .ifSeqNo(5)
+            .ifPrimaryTerm(2)
+            .build();
 
         doAnswer(invocation -> {
             ActionListener<UpdateResponse> listener = invocation.getArgument(1);
             RemoteTransportException rte = Mockito.mock(RemoteTransportException.class);
-            when(rte.getCause()).thenReturn(new VersionConflictEngineException(new ShardId(TEST_INDEX, "_na_", 0),
-                    TEST_ID, "test"));
+            when(rte.getCause()).thenReturn(new VersionConflictEngineException(new ShardId(TEST_INDEX, "_na_", 0), TEST_ID, "test"));
             listener.onFailure(rte);
             return null;
         }).when(mockedClient).update(any(UpdateRequest.class), any());


### PR DESCRIPTION
### Description

we need to unwrap the cause before checking whether it is a VersionConflictEngineException,
the original ex may be a RemoteTransportException

### Issues Resolved

https://github.com/opensearch-project/flow-framework/issues/1082

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
