### PR TITLE
Use SdkClientDelegate's classloader for ServiceLoader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,24 +8,10 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Enhancements
 ### Bug Fixes
 - Fix version conflict check for update ([#114](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/114))
+- Use SdkClientDelegate's classloader for ServiceLoader ([#121](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/121))
 
 ### Infrastructure
 ### Documentation
 ### Maintenance
 ### Refactoring
 - Update o.o.client imports to o.o.transport.client ([#73](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/73))
-
-## [Unreleased 2.x](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/compare/2.19...2.x)
-### Features
-### Enhancements
-- Improve exception unwrapping flexibility for SdkClientUtils ([#67](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/67))
-- Add util methods to handle ActionListeners in whenComplete ([#75](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/75))
-- Make DynamoDBClient fully async ([#79](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/79))
-- Make Remote Cluster Client and AOS client fully async ([#80](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/80))
-
-### Bug Fixes
-### Infrastructure
-### Documentation
-### Maintenance
-- Bump aws sdk to 2.30.18 from 2.29.50 ([#93](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/93))
-### Refactoring

--- a/aos-client/src/test/java/org/opensearch/remote/metadata/client/impl/AOSSdkClientFactoryTests.java
+++ b/aos-client/src/test/java/org/opensearch/remote/metadata/client/impl/AOSSdkClientFactoryTests.java
@@ -64,6 +64,32 @@ public class AOSSdkClientFactoryTests {
     }
 
     @Test
+    public void testAWSOpenSearchBindingWithOtherClassLoader() {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            // Set a classloader that can't see the implementation
+            Thread.currentThread().setContextClassLoader(new ClassLoader(null) {
+                @Override
+                public Class<?> loadClass(String name) throws ClassNotFoundException {
+                    throw new ClassNotFoundException("Simulating restricted access");
+                }
+            });
+
+            Map<String, String> settings = Map.ofEntries(
+                Map.entry(REMOTE_METADATA_TYPE_KEY, AWS_OPENSEARCH_SERVICE),
+                Map.entry(REMOTE_METADATA_ENDPOINT_KEY, "example.org"),
+                Map.entry(REMOTE_METADATA_REGION_KEY, "eu-west-3"),
+                Map.entry(REMOTE_METADATA_SERVICE_NAME_KEY, "es")
+            );
+            SdkClient sdkClient = SdkClientFactory.createSdkClient(mock(Client.class), NamedXContentRegistry.EMPTY, settings);
+            assertTrue(sdkClient.getDelegate() instanceof AOSOpenSearchClient);
+            resourcesToClose.add(sdkClient.getDelegate());
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    @Test
     public void testAwsOpenSearchServiceBindingException() {
         Map<String, String> settings = Map.of(REMOTE_METADATA_TYPE_KEY, AWS_OPENSEARCH_SERVICE);
         assertThrows(

--- a/core/src/main/java/org/opensearch/remote/metadata/client/impl/SdkClientFactory.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/impl/SdkClientFactory.java
@@ -59,7 +59,7 @@ public class SdkClientFactory {
         String remoteMetadataType = metadataSettings.get(REMOTE_METADATA_TYPE_KEY);
         Boolean multiTenancy = Boolean.parseBoolean(metadataSettings.get(TENANT_AWARE_KEY));
 
-        ServiceLoader<SdkClientDelegate> loader = ServiceLoader.load(SdkClientDelegate.class);
+        ServiceLoader<SdkClientDelegate> loader = ServiceLoader.load(SdkClientDelegate.class, SdkClientDelegate.class.getClassLoader());
         Iterator<SdkClientDelegate> iterator = loader.iterator();
 
         if (Strings.isNullOrEmpty(remoteMetadataType)) {


### PR DESCRIPTION
### Description

The ServiceLoader needs the correct classloader to find service implementations in the classpath. Using `SdkClientDelegate.class.getClassLoader()` ensures we use the classloader that loaded the interface, which has access to both the interface and its implementations within the security context of the implementing plugins.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
