### PR TITLE
[Backport 2.19] Use SdkClientDelegate's classloader for ServiceLoader (#121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,16 +3,12 @@ All notable changes to this project are documented in this file.
 
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
-## [Unreleased 2.x](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/compare/2.19...2.x)
 ### Features
 ### Enhancements
 ### Bug Fixes
-- Improve exception unwrapping flexibility for SdkClientUtils ([#67](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/67))
-- Add util methods to handle ActionListeners in whenComplete ([#75](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/75))
-- Refactor SDKClientUtil for better readability, fix javadocs ([#78](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/78))
-- Make DynamoDBClient fully async ([#79](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/79))
+- Use SdkClientDelegate's classloader for ServiceLoader ([#121](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/121))
+
 ### Infrastructure
 ### Documentation
 ### Maintenance
-- Bump aws sdk to 2.30.18 from 2.29.50 ([#93](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/93))
 ### Refactoring

--- a/aos-client/src/test/java/org/opensearch/remote/metadata/client/impl/AOSSdkClientFactoryTests.java
+++ b/aos-client/src/test/java/org/opensearch/remote/metadata/client/impl/AOSSdkClientFactoryTests.java
@@ -64,6 +64,32 @@ public class AOSSdkClientFactoryTests {
     }
 
     @Test
+    public void testAWSOpenSearchBindingWithOtherClassLoader() {
+        ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+        try {
+            // Set a classloader that can't see the implementation
+            Thread.currentThread().setContextClassLoader(new ClassLoader(null) {
+                @Override
+                public Class<?> loadClass(String name) throws ClassNotFoundException {
+                    throw new ClassNotFoundException("Simulating restricted access");
+                }
+            });
+
+            Map<String, String> settings = Map.ofEntries(
+                Map.entry(REMOTE_METADATA_TYPE_KEY, AWS_OPENSEARCH_SERVICE),
+                Map.entry(REMOTE_METADATA_ENDPOINT_KEY, "example.org"),
+                Map.entry(REMOTE_METADATA_REGION_KEY, "eu-west-3"),
+                Map.entry(REMOTE_METADATA_SERVICE_NAME_KEY, "es")
+            );
+            SdkClient sdkClient = SdkClientFactory.createSdkClient(mock(Client.class), NamedXContentRegistry.EMPTY, settings);
+            assertTrue(sdkClient.getDelegate() instanceof AOSOpenSearchClient);
+            resourcesToClose.add(sdkClient.getDelegate());
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalClassLoader);
+        }
+    }
+
+    @Test
     public void testAwsOpenSearchServiceBindingException() {
         Map<String, String> settings = Map.of(REMOTE_METADATA_TYPE_KEY, AWS_OPENSEARCH_SERVICE);
         assertThrows(

--- a/core/src/main/java/org/opensearch/remote/metadata/client/impl/SdkClientFactory.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/impl/SdkClientFactory.java
@@ -59,7 +59,7 @@ public class SdkClientFactory {
         String remoteMetadataType = metadataSettings.get(REMOTE_METADATA_TYPE_KEY);
         Boolean multiTenancy = Boolean.parseBoolean(metadataSettings.get(TENANT_AWARE_KEY));
 
-        ServiceLoader<SdkClientDelegate> loader = ServiceLoader.load(SdkClientDelegate.class);
+        ServiceLoader<SdkClientDelegate> loader = ServiceLoader.load(SdkClientDelegate.class, SdkClientDelegate.class.getClassLoader());
         Iterator<SdkClientDelegate> iterator = loader.iterator();
 
         if (Strings.isNullOrEmpty(remoteMetadataType)) {


### PR DESCRIPTION
Backports c3706acd2c7a13000ec38b0e1d83c6ad630e1e56 from #121 