### PR TITLE
Ensure consistent reads on DynamoDB getItem calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Bug Fixes
 - Fix version conflict check for update ([#114](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/114))
 - Use SdkClientDelegate's classloader for ServiceLoader ([#121](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/121))
+- Ensure consistent reads on DynamoDB getItem calls ([#128](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/128))
 
 ### Infrastructure
 ### Documentation

--- a/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClient.java
+++ b/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClient.java
@@ -599,6 +599,7 @@ public class DDBOpenSearchClient extends AbstractSdkClient {
                     Map.entry(RANGE_KEY, AttributeValue.builder().s(documentId).build())
                 )
             )
+            .consistentRead(true)
             .build();
     }
 


### PR DESCRIPTION
### Description

Ensures `getItem()` calls are strongly consistent. This matches OpenSearch's strongly consistent guarantee for get-by-id calls.

### Issues Resolved

Fixes #127 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
