### PR TITLE
Added required fields to PutDataObjectRequest inorder to support opensearch store

### DIFF
--- a/core/src/main/java/org/opensearch/remote/metadata/client/PutDataObjectRequest.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/PutDataObjectRequest.java
@@ -8,10 +8,13 @@
  */
 package org.opensearch.remote.metadata.client;
 
+import org.opensearch.action.support.WriteRequest.RefreshPolicy;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.xcontent.ToXContentObject;
 
 import java.util.Map;
 
+import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 /**
  * A class abstracting an OpenSearch IndexRequest
  */
@@ -19,6 +22,10 @@ public class PutDataObjectRequest extends DataObjectRequest {
 
     private final boolean overwriteIfExists;
     private final ToXContentObject dataObject;
+    private final RefreshPolicy refreshPolicy;
+    private final Long ifSeqNo;
+    private final Long ifPrimaryTerm;
+    private final TimeValue timeout;
 
     /**
      * Instantiate this request with an index and data object.
@@ -29,11 +36,19 @@ public class PutDataObjectRequest extends DataObjectRequest {
      * @param tenantId the tenant id
      * @param overwriteIfExists whether to overwrite the document if it exists (update)
      * @param dataObject the data object
+     * @param refreshPolicy the refresh policy to match, by default set as IMMEDIATE
+     * @param ifSeqNo the sequence number to match or null if not required
+     * @param ifPrimaryTerm the primary term to match or null if not required
+     * @param timeout the timeout to match or null if not required
      */
-    public PutDataObjectRequest(String index, String id, String tenantId, boolean overwriteIfExists, ToXContentObject dataObject) {
+    public PutDataObjectRequest(String index, String id, String tenantId, boolean overwriteIfExists, ToXContentObject dataObject, RefreshPolicy refreshPolicy, Long ifSeqNo, Long ifPrimaryTerm, TimeValue timeout) {
         super(index, id, tenantId);
         this.overwriteIfExists = overwriteIfExists;
         this.dataObject = dataObject;
+        this.refreshPolicy = refreshPolicy;
+        this.ifSeqNo = ifSeqNo;
+        this.ifPrimaryTerm = ifPrimaryTerm;
+        this.timeout = timeout;
     }
 
     /**
@@ -43,6 +58,34 @@ public class PutDataObjectRequest extends DataObjectRequest {
     public boolean overwriteIfExists() {
         return this.overwriteIfExists;
     }
+
+    /**
+     * Returns the refresh policy for this request
+     * @return the refreshPolicy
+     */
+    public RefreshPolicy refreshPolicy() { return refreshPolicy; }
+
+    /**
+     * Returns the sequence number to match, or null if no match required
+     * @return the ifSeqNo
+     */
+    public Long ifSeqNo() {
+        return ifSeqNo;
+    }
+
+    /**
+     * Returns the primary term to match, or null if no match required
+     * @return the ifPrimaryTerm
+     */
+    public Long ifPrimaryTerm() {
+        return ifPrimaryTerm;
+    }
+
+    /**
+     * Returns the timeout value for this request, or null if not specified
+     * @return the timeout
+     */
+    public TimeValue timeout() { return timeout; }
 
     /**
      * Returns the data object
@@ -71,6 +114,63 @@ public class PutDataObjectRequest extends DataObjectRequest {
     public static class Builder extends DataObjectRequest.Builder<Builder> {
         private boolean overwriteIfExists = true;
         private ToXContentObject dataObject = null;
+        private Long ifSeqNo = null;
+        private Long ifPrimaryTerm = null;
+        private TimeValue timeout = null;
+        private RefreshPolicy refreshPolicy = RefreshPolicy.IMMEDIATE;
+
+        /**
+         * Sets the refresh policy for this request
+         * refresh policy may not be relevant on non-OpenSearch data stores.
+         * @param refreshPolicy the refresh policy to use
+         * @return the updated builder
+         */
+        public Builder refreshPolicy(RefreshPolicy refreshPolicy) {
+            this.refreshPolicy = refreshPolicy;
+            return this;
+        }
+
+        /**
+         * Only perform this index request if the document's modification was assigned the given
+         * sequence number. Must be used in combination with {@link #ifPrimaryTerm(long)}
+         * <p>
+         * Sequence number may be represented by a different document versioning key on non-OpenSearch data stores.
+         * @param seqNo the sequence number
+         * @return the updated builder
+         */
+        public PutDataObjectRequest.Builder ifSeqNo(long seqNo) {
+            if (seqNo < 0 && seqNo != UNASSIGNED_SEQ_NO) {
+                throw new IllegalArgumentException("sequence numbers must be non negative. got [" + seqNo + "].");
+            }
+            this.ifSeqNo = seqNo;
+            return this;
+        }
+
+        /**
+         * Only performs this index request if the document's last modification was assigned the given
+         * primary term. Must be used in combination with {@link #ifSeqNo(long)}
+         * <p>
+         * Primary term may not be relevant on non-OpenSearch data stores.
+         * @param term the primary term
+         * @return the updated builder
+         */
+        public Builder ifPrimaryTerm(long term) {
+            if (term < 0) {
+                throw new IllegalArgumentException("primary term must be non negative. got [" + term + "]");
+            }
+            this.ifPrimaryTerm = term;
+            return this;
+        }
+
+        /**
+         * Sets the timeout for this request
+         * @param timeout the timeout value
+         * @return the updated builder
+         */
+        public Builder timeout(TimeValue timeout) {
+            this.timeout = timeout;
+            return this;
+        }
 
         /**
          * Specify whether to overwrite an existing document/item (upsert). True by default.
@@ -107,7 +207,7 @@ public class PutDataObjectRequest extends DataObjectRequest {
          * @return A {@link PutDataObjectRequest}
          */
         public PutDataObjectRequest build() {
-            return new PutDataObjectRequest(this.index, this.id, this.tenantId, this.overwriteIfExists, this.dataObject);
+            return new PutDataObjectRequest(this.index, this.id, this.tenantId, this.overwriteIfExists, this.dataObject, this.refreshPolicy, this.ifSeqNo, this.ifPrimaryTerm, this.timeout);
         }
     }
 }

--- a/core/src/main/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClient.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClient.java
@@ -19,6 +19,7 @@ import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.get.GetRequest;
 import org.opensearch.action.index.IndexRequest;
+import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -105,7 +106,7 @@ public class LocalClusterIndicesClient extends AbstractSdkClient {
         return doPrivileged(() -> {
             try {
                 log.info("Indexing data object in {}", request.index());
-                IndexRequest indexRequest = createIndexRequest(request).setRefreshPolicy(IMMEDIATE);
+                IndexRequest indexRequest = createIndexRequest(request);
                 client.index(indexRequest, ActionListener.wrap(indexResponse -> {
                     log.info("Creation status for id {}: {}", indexResponse.getId(), indexResponse.getResult());
                     try {
@@ -152,6 +153,18 @@ public class LocalClusterIndicesClient extends AbstractSdkClient {
             ).source(putDataObjectRequest.dataObject().toXContent(sourceBuilder, EMPTY_PARAMS));
             if (!Strings.isNullOrEmpty(putDataObjectRequest.id())) {
                 indexRequest.id(putDataObjectRequest.id());
+            }
+            if (putDataObjectRequest.ifSeqNo() != null) {
+                indexRequest.setIfSeqNo(putDataObjectRequest.ifSeqNo());
+            }
+            if (putDataObjectRequest.ifPrimaryTerm() != null) {
+                indexRequest.setIfPrimaryTerm(putDataObjectRequest.ifPrimaryTerm());
+            }
+            if (putDataObjectRequest.timeout() != null) {
+                indexRequest.timeout(putDataObjectRequest.timeout());
+            }
+            if (putDataObjectRequest.refreshPolicy() != null) {
+                indexRequest.setRefreshPolicy(putDataObjectRequest.refreshPolicy());
             }
             return indexRequest;
         }


### PR DESCRIPTION
### Description
Added required fields to the PutDataObjectRequest inorder to support Opensearch specific store. 
The fields that are newly added are 
```
Long ifSeqNo;
Long ifPrimaryTerm;
TimeValue timeout;
RefreshPolicy refreshPolicy;
```

Added full test coverage for new and existing fields

### Issues Resolved
- #136 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
