### PR TITLE
Directly return responses from Local Cluster client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Features
 ### Enhancements
 ### Bug Fixes
+- Directly return responses from Local Cluster client ([#141](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/141))
+
 ### Infrastructure
 ### Documentation
 ### Maintenance

--- a/core/src/main/java/org/opensearch/remote/metadata/client/AbstractSdkClient.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/AbstractSdkClient.java
@@ -44,7 +44,7 @@ public abstract class AbstractSdkClient implements SdkClientDelegate {
     }
 
     /**
-     * Execute this priveleged action asynchronously
+     * Execute this privileged action asynchronously
      * @param <T> The return type of the completable future to be returned
      * @param action the action to execute
      * @param executor the executor for the action

--- a/core/src/main/java/org/opensearch/remote/metadata/client/SearchDataObjectResponse.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/SearchDataObjectResponse.java
@@ -8,27 +8,67 @@
  */
 package org.opensearch.remote.metadata.client;
 
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.common.Nullable;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.remote.metadata.common.SdkClientUtils;
+
+import java.io.IOException;
 
 /**
  * A class abstracting an OpenSearch SearchResponse
  */
 public class SearchDataObjectResponse {
+    // Only one of these will be non-null
     private final XContentParser parser;
+    private final SearchResponse searchResponse;
 
     /**
-     * Instantiate this request with a parser used to recreate the response.
+     * Instantiate this response with a {@link SearchResponse}.
+     * @param searchResponse a pre-completed Search response
+     */
+    public SearchDataObjectResponse(SearchResponse searchResponse) {
+        this.searchResponse = searchResponse;
+        this.parser = null;
+    }
+
+    /**
+     * Instantiate this response with a parser used to recreate a {@link SearchResponse}.
      * @param parser an XContentParser that can be used to create the response.
      */
     public SearchDataObjectResponse(XContentParser parser) {
         this.parser = parser;
+        this.searchResponse = null;
+    }
+
+    /**
+     * Returns the SearchResponse object
+     * @return the search response if present, or parsed otherwise
+     */
+    public @Nullable SearchResponse searchResponse() {
+        if (this.searchResponse == null) {
+            try {
+                return SearchResponse.fromXContent(this.parser);
+            } catch (IOException | NullPointerException e) {
+                return null;
+            }
+        }
+        return this.searchResponse;
     }
 
     /**
      * Returns the parser
      * @return the parser
+     * @throws IOException on a failure to create the parser if created from the SearchResponse object
      */
     public XContentParser parser() {
+        if (this.parser == null) {
+            try {
+                return SdkClientUtils.createParser(searchResponse);
+            } catch (IOException | NullPointerException e) {
+                return null;
+            }
+        }
         return this.parser;
     }
 
@@ -52,7 +92,7 @@ public class SearchDataObjectResponse {
         private Builder() {}
 
         /**
-         * Add aparser to this builder
+         * Add a parser to this builder
          * @param parser a parser
          * @return the updated builder
          */

--- a/core/src/main/java/org/opensearch/remote/metadata/common/SdkClientUtils.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/common/SdkClientUtils.java
@@ -19,30 +19,137 @@ import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.common.action.ActionFuture;
 import org.opensearch.common.util.concurrent.FutureUtils;
 import org.opensearch.common.util.concurrent.UncategorizedExecutionException;
+import org.opensearch.core.ParseField;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.Strings;
+import org.opensearch.core.xcontent.ContextParser;
+import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.MediaTypeRegistry;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.remote.metadata.client.BulkDataObjectResponse;
 import org.opensearch.remote.metadata.client.DeleteDataObjectResponse;
 import org.opensearch.remote.metadata.client.GetDataObjectResponse;
 import org.opensearch.remote.metadata.client.PutDataObjectResponse;
 import org.opensearch.remote.metadata.client.SearchDataObjectResponse;
 import org.opensearch.remote.metadata.client.UpdateDataObjectResponse;
+import org.opensearch.search.aggregations.Aggregation;
+import org.opensearch.search.aggregations.bucket.adjacency.AdjacencyMatrixAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.adjacency.ParsedAdjacencyMatrix;
+import org.opensearch.search.aggregations.bucket.composite.CompositeAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.composite.ParsedComposite;
+import org.opensearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.filter.FiltersAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.filter.ParsedFilter;
+import org.opensearch.search.aggregations.bucket.filter.ParsedFilters;
+import org.opensearch.search.aggregations.bucket.global.GlobalAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.global.ParsedGlobal;
+import org.opensearch.search.aggregations.bucket.histogram.AutoDateHistogramAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.histogram.ParsedAutoDateHistogram;
+import org.opensearch.search.aggregations.bucket.histogram.ParsedDateHistogram;
+import org.opensearch.search.aggregations.bucket.histogram.ParsedHistogram;
+import org.opensearch.search.aggregations.bucket.histogram.ParsedVariableWidthHistogram;
+import org.opensearch.search.aggregations.bucket.histogram.VariableWidthHistogramAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.missing.MissingAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.missing.ParsedMissing;
+import org.opensearch.search.aggregations.bucket.nested.NestedAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.nested.ParsedNested;
+import org.opensearch.search.aggregations.bucket.nested.ParsedReverseNested;
+import org.opensearch.search.aggregations.bucket.nested.ReverseNestedAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.range.DateRangeAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.range.GeoDistanceAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.range.IpRangeAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.range.ParsedBinaryRange;
+import org.opensearch.search.aggregations.bucket.range.ParsedDateRange;
+import org.opensearch.search.aggregations.bucket.range.ParsedGeoDistance;
+import org.opensearch.search.aggregations.bucket.range.ParsedRange;
+import org.opensearch.search.aggregations.bucket.range.RangeAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.sampler.InternalSampler;
+import org.opensearch.search.aggregations.bucket.sampler.ParsedSampler;
+import org.opensearch.search.aggregations.bucket.terms.DoubleTerms;
+import org.opensearch.search.aggregations.bucket.terms.LongTerms;
+import org.opensearch.search.aggregations.bucket.terms.MultiTermsAggregationBuilder;
+import org.opensearch.search.aggregations.bucket.terms.ParsedDoubleTerms;
+import org.opensearch.search.aggregations.bucket.terms.ParsedLongTerms;
+import org.opensearch.search.aggregations.bucket.terms.ParsedMultiTerms;
+import org.opensearch.search.aggregations.bucket.terms.ParsedSignificantLongTerms;
+import org.opensearch.search.aggregations.bucket.terms.ParsedSignificantStringTerms;
+import org.opensearch.search.aggregations.bucket.terms.ParsedStringTerms;
+import org.opensearch.search.aggregations.bucket.terms.SignificantLongTerms;
+import org.opensearch.search.aggregations.bucket.terms.SignificantStringTerms;
+import org.opensearch.search.aggregations.bucket.terms.StringTerms;
+import org.opensearch.search.aggregations.metrics.AvgAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.CardinalityAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.ExtendedStatsAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.GeoCentroidAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.InternalHDRPercentileRanks;
+import org.opensearch.search.aggregations.metrics.InternalHDRPercentiles;
+import org.opensearch.search.aggregations.metrics.InternalTDigestPercentileRanks;
+import org.opensearch.search.aggregations.metrics.InternalTDigestPercentiles;
+import org.opensearch.search.aggregations.metrics.MaxAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.MedianAbsoluteDeviationAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.MinAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.ParsedAvg;
+import org.opensearch.search.aggregations.metrics.ParsedCardinality;
+import org.opensearch.search.aggregations.metrics.ParsedExtendedStats;
+import org.opensearch.search.aggregations.metrics.ParsedGeoCentroid;
+import org.opensearch.search.aggregations.metrics.ParsedHDRPercentileRanks;
+import org.opensearch.search.aggregations.metrics.ParsedHDRPercentiles;
+import org.opensearch.search.aggregations.metrics.ParsedMax;
+import org.opensearch.search.aggregations.metrics.ParsedMedianAbsoluteDeviation;
+import org.opensearch.search.aggregations.metrics.ParsedMin;
+import org.opensearch.search.aggregations.metrics.ParsedScriptedMetric;
+import org.opensearch.search.aggregations.metrics.ParsedStats;
+import org.opensearch.search.aggregations.metrics.ParsedSum;
+import org.opensearch.search.aggregations.metrics.ParsedTDigestPercentileRanks;
+import org.opensearch.search.aggregations.metrics.ParsedTDigestPercentiles;
+import org.opensearch.search.aggregations.metrics.ParsedTopHits;
+import org.opensearch.search.aggregations.metrics.ParsedValueCount;
+import org.opensearch.search.aggregations.metrics.ParsedWeightedAvg;
+import org.opensearch.search.aggregations.metrics.ScriptedMetricAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.StatsAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.SumAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.TopHitsAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.ValueCountAggregationBuilder;
+import org.opensearch.search.aggregations.metrics.WeightedAvgAggregationBuilder;
+import org.opensearch.search.aggregations.pipeline.DerivativePipelineAggregationBuilder;
+import org.opensearch.search.aggregations.pipeline.ExtendedStatsBucketPipelineAggregationBuilder;
+import org.opensearch.search.aggregations.pipeline.InternalBucketMetricValue;
+import org.opensearch.search.aggregations.pipeline.InternalSimpleValue;
+import org.opensearch.search.aggregations.pipeline.ParsedBucketMetricValue;
+import org.opensearch.search.aggregations.pipeline.ParsedDerivative;
+import org.opensearch.search.aggregations.pipeline.ParsedExtendedStatsBucket;
+import org.opensearch.search.aggregations.pipeline.ParsedPercentilesBucket;
+import org.opensearch.search.aggregations.pipeline.ParsedSimpleValue;
+import org.opensearch.search.aggregations.pipeline.ParsedStatsBucket;
+import org.opensearch.search.aggregations.pipeline.PercentilesBucketPipelineAggregationBuilder;
+import org.opensearch.search.aggregations.pipeline.StatsBucketPipelineAggregationBuilder;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiConsumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
+import static org.opensearch.common.xcontent.json.JsonXContent.jsonXContent;
 import static org.opensearch.core.rest.RestStatus.INTERNAL_SERVER_ERROR;
 
 /**
  * Utility methods for client implementations
  */
 public class SdkClientUtils {
+
+    private static final NamedXContentRegistry DEFAULT_XCONTENT_REGISTRY = createDefaultXContentRegistry();
 
     private SdkClientUtils() {}
 
@@ -63,12 +170,12 @@ public class SdkClientUtils {
                 handleThrowable(listener, throwable, exceptionTypesToUnwrap);
                 return;
             }
-            try {
-                IndexResponse indexResponse = r.parser() == null ? null : IndexResponse.fromXContent(r.parser());
-                listener.onResponse(indexResponse);
-            } catch (IOException e) {
-                handleParseFailure(listener, "put");
+            IndexResponse indexResponse = r.indexResponse();
+            if (indexResponse == null) {
+                handleParseFailure(listener, "index");
+                return;
             }
+            listener.onResponse(indexResponse);
         };
     }
 
@@ -89,12 +196,12 @@ public class SdkClientUtils {
                 handleThrowable(listener, throwable, exceptionTypesToUnwrap);
                 return;
             }
-            try {
-                GetResponse getResponse = r.parser() == null ? null : GetResponse.fromXContent(r.parser());
-                listener.onResponse(getResponse);
-            } catch (IOException e) {
+            GetResponse getResponse = r.getResponse();
+            if (getResponse == null) {
                 handleParseFailure(listener, "get");
+                return;
             }
+            listener.onResponse(getResponse);
         };
     }
 
@@ -115,13 +222,14 @@ public class SdkClientUtils {
                 handleThrowable(listener, throwable, exceptionTypesToUnwrap);
                 return;
             }
-            try {
-                UpdateResponse updateResponse = r.parser() == null ? null : UpdateResponse.fromXContent(r.parser());
-                listener.onResponse(updateResponse);
-            } catch (IOException e) {
+            UpdateResponse updateResponse = r.updateResponse();
+            if (updateResponse == null) {
                 handleParseFailure(listener, "update");
+                return;
             }
+            listener.onResponse(updateResponse);
         };
+
     }
 
     /**
@@ -141,12 +249,12 @@ public class SdkClientUtils {
                 handleThrowable(listener, throwable, exceptionTypesToUnwrap);
                 return;
             }
-            try {
-                DeleteResponse deleteResponse = r.parser() == null ? null : DeleteResponse.fromXContent(r.parser());
-                listener.onResponse(deleteResponse);
-            } catch (IOException e) {
+            DeleteResponse deleteResponse = r.deleteResponse();
+            if (deleteResponse == null) {
                 handleParseFailure(listener, "delete");
+                return;
             }
+            listener.onResponse(deleteResponse);
         };
     }
 
@@ -167,12 +275,12 @@ public class SdkClientUtils {
                 handleThrowable(listener, throwable, exceptionTypesToUnwrap);
                 return;
             }
-            try {
-                BulkResponse bulkResponse = r.parser() == null ? null : BulkResponse.fromXContent(r.parser());
-                listener.onResponse(bulkResponse);
-            } catch (IOException e) {
+            BulkResponse bulkResponse = r.bulkResponse();
+            if (bulkResponse == null) {
                 handleParseFailure(listener, "bulk");
+                return;
             }
+            listener.onResponse(bulkResponse);
         };
     }
 
@@ -193,13 +301,33 @@ public class SdkClientUtils {
                 handleThrowable(listener, throwable, exceptionTypesToUnwrap);
                 return;
             }
-            try {
-                SearchResponse searchResponse = r.parser() == null ? null : SearchResponse.fromXContent(r.parser());
-                listener.onResponse(searchResponse);
-            } catch (IOException e) {
+            SearchResponse searchResponse = r.searchResponse();
+            if (searchResponse == null) {
                 handleParseFailure(listener, "search");
+                return;
             }
+            listener.onResponse(searchResponse);
         };
+    }
+
+    /**
+     * Create a parser from a {@link ToXContent} object
+     * @param obj The object to convert to a parser
+     * @return the parser
+     * @throws IOException on a parsing failure
+     */
+    public static XContentParser createParser(ToXContent obj) throws IOException {
+        return createParser(Strings.toString(MediaTypeRegistry.JSON, obj));
+    }
+
+    /**
+     * Create a parser from a JSON string
+     * @param json The string to convert to a parser
+     * @return the parser
+     * @throws IOException on a parsing failure
+     */
+    public static XContentParser createParser(String json) throws IOException {
+        return jsonXContent.createParser(DEFAULT_XCONTENT_REGISTRY, DeprecationHandler.IGNORE_DEPRECATIONS, json);
     }
 
     private static void handleParseFailure(ActionListener<?> listener, String operation) {
@@ -268,6 +396,12 @@ public class SdkClientUtils {
      * @return The JSON with the value lowercased
      */
     public static String lowerCaseEnumValues(String field, String json) {
+        if (field == null) {
+            return json;
+        }
+        if (json == null) {
+            return null;
+        }
         // Use a matcher to find and replace the field value in lowercase
         Matcher matcher = Pattern.compile("(\"" + Pattern.quote(field) + "\"):(\"[A-Z_]+\")").matcher(json);
         StringBuffer sb = new StringBuffer();
@@ -276,5 +410,68 @@ public class SdkClientUtils {
         }
         matcher.appendTail(sb);
         return sb.toString();
+    }
+
+    private static NamedXContentRegistry createDefaultXContentRegistry() {
+        List<NamedXContentRegistry.Entry> entries = new ArrayList<>();
+        entries.addAll(getDefaultNamedXContents());
+        return new NamedXContentRegistry(entries);
+    }
+
+    private static List<NamedXContentRegistry.Entry> getDefaultNamedXContents() {
+        Map<String, ContextParser<Object, ? extends Aggregation>> map = Map.ofEntries(
+            Map.entry(AvgAggregationBuilder.NAME, (p, c) -> ParsedAvg.fromXContent(p, (String) c)),
+            Map.entry(WeightedAvgAggregationBuilder.NAME, (p, c) -> ParsedWeightedAvg.fromXContent(p, (String) c)),
+            Map.entry(SumAggregationBuilder.NAME, (p, c) -> ParsedSum.fromXContent(p, (String) c)),
+            Map.entry(MinAggregationBuilder.NAME, (p, c) -> ParsedMin.fromXContent(p, (String) c)),
+            Map.entry(MaxAggregationBuilder.NAME, (p, c) -> ParsedMax.fromXContent(p, (String) c)),
+            Map.entry(StatsAggregationBuilder.NAME, (p, c) -> ParsedStats.fromXContent(p, (String) c)),
+            Map.entry(ExtendedStatsAggregationBuilder.NAME, (p, c) -> ParsedExtendedStats.fromXContent(p, (String) c)),
+            Map.entry(ValueCountAggregationBuilder.NAME, (p, c) -> ParsedValueCount.fromXContent(p, (String) c)),
+            Map.entry(InternalTDigestPercentiles.NAME, (p, c) -> ParsedTDigestPercentiles.fromXContent(p, (String) c)),
+            Map.entry(InternalHDRPercentiles.NAME, (p, c) -> ParsedHDRPercentiles.fromXContent(p, (String) c)),
+            Map.entry(InternalTDigestPercentileRanks.NAME, (p, c) -> ParsedTDigestPercentileRanks.fromXContent(p, (String) c)),
+            Map.entry(InternalHDRPercentileRanks.NAME, (p, c) -> ParsedHDRPercentileRanks.fromXContent(p, (String) c)),
+            Map.entry(MedianAbsoluteDeviationAggregationBuilder.NAME, (p, c) -> ParsedMedianAbsoluteDeviation.fromXContent(p, (String) c)),
+            Map.entry(CardinalityAggregationBuilder.NAME, (p, c) -> ParsedCardinality.fromXContent(p, (String) c)),
+            Map.entry(GlobalAggregationBuilder.NAME, (p, c) -> ParsedGlobal.fromXContent(p, (String) c)),
+            Map.entry(MissingAggregationBuilder.NAME, (p, c) -> ParsedMissing.fromXContent(p, (String) c)),
+            Map.entry(FilterAggregationBuilder.NAME, (p, c) -> ParsedFilter.fromXContent(p, (String) c)),
+            Map.entry(FiltersAggregationBuilder.NAME, (p, c) -> ParsedFilters.fromXContent(p, (String) c)),
+            Map.entry(AdjacencyMatrixAggregationBuilder.NAME, (p, c) -> ParsedAdjacencyMatrix.fromXContent(p, (String) c)),
+            Map.entry(InternalSampler.NAME, (p, c) -> ParsedSampler.fromXContent(p, (String) c)),
+            Map.entry(StringTerms.NAME, (p, c) -> ParsedStringTerms.fromXContent(p, (String) c)),
+            Map.entry(LongTerms.NAME, (p, c) -> ParsedLongTerms.fromXContent(p, (String) c)),
+            Map.entry(DoubleTerms.NAME, (p, c) -> ParsedDoubleTerms.fromXContent(p, (String) c)),
+            Map.entry(SignificantLongTerms.NAME, (p, c) -> ParsedSignificantLongTerms.fromXContent(p, (String) c)),
+            Map.entry(SignificantStringTerms.NAME, (p, c) -> ParsedSignificantStringTerms.fromXContent(p, (String) c)),
+            Map.entry(RangeAggregationBuilder.NAME, (p, c) -> ParsedRange.fromXContent(p, (String) c)),
+            Map.entry(DateRangeAggregationBuilder.NAME, (p, c) -> ParsedDateRange.fromXContent(p, (String) c)),
+            Map.entry(IpRangeAggregationBuilder.NAME, (p, c) -> ParsedBinaryRange.fromXContent(p, (String) c)),
+            Map.entry(HistogramAggregationBuilder.NAME, (p, c) -> ParsedHistogram.fromXContent(p, (String) c)),
+            Map.entry(DateHistogramAggregationBuilder.NAME, (p, c) -> ParsedDateHistogram.fromXContent(p, (String) c)),
+            Map.entry(AutoDateHistogramAggregationBuilder.NAME, (p, c) -> ParsedAutoDateHistogram.fromXContent(p, (String) c)),
+            Map.entry(VariableWidthHistogramAggregationBuilder.NAME, (p, c) -> ParsedVariableWidthHistogram.fromXContent(p, (String) c)),
+            Map.entry(GeoDistanceAggregationBuilder.NAME, (p, c) -> ParsedGeoDistance.fromXContent(p, (String) c)),
+            Map.entry(NestedAggregationBuilder.NAME, (p, c) -> ParsedNested.fromXContent(p, (String) c)),
+            Map.entry(ReverseNestedAggregationBuilder.NAME, (p, c) -> ParsedReverseNested.fromXContent(p, (String) c)),
+            Map.entry(TopHitsAggregationBuilder.NAME, (p, c) -> ParsedTopHits.fromXContent(p, (String) c)),
+            Map.entry(GeoCentroidAggregationBuilder.NAME, (p, c) -> ParsedGeoCentroid.fromXContent(p, (String) c)),
+            Map.entry(ScriptedMetricAggregationBuilder.NAME, (p, c) -> ParsedScriptedMetric.fromXContent(p, (String) c)),
+            Map.entry(CompositeAggregationBuilder.NAME, (p, c) -> ParsedComposite.fromXContent(p, (String) c)),
+            Map.entry(MultiTermsAggregationBuilder.NAME, (p, c) -> ParsedMultiTerms.fromXContent(p, (String) c)),
+            Map.entry(PercentilesBucketPipelineAggregationBuilder.NAME, (p, c) -> ParsedPercentilesBucket.fromXContent(p, (String) c)),
+            Map.entry(InternalSimpleValue.NAME, (p, c) -> ParsedSimpleValue.fromXContent(p, (String) c)),
+            Map.entry(DerivativePipelineAggregationBuilder.NAME, (p, c) -> ParsedDerivative.fromXContent(p, (String) c)),
+            Map.entry(InternalBucketMetricValue.NAME, (p, c) -> ParsedBucketMetricValue.fromXContent(p, (String) c)),
+            Map.entry(StatsBucketPipelineAggregationBuilder.NAME, (p, c) -> ParsedStatsBucket.fromXContent(p, (String) c)),
+            Map.entry(ExtendedStatsBucketPipelineAggregationBuilder.NAME, (p, c) -> ParsedExtendedStatsBucket.fromXContent(p, (String) c))
+        );
+
+        List<NamedXContentRegistry.Entry> entries = map.entrySet()
+            .stream()
+            .map((entry) -> new NamedXContentRegistry.Entry(Aggregation.class, new ParseField((String) entry.getKey()), entry.getValue()))
+            .collect(Collectors.toList());
+        return entries;
     }
 }

--- a/core/src/test/java/org/opensearch/remote/metadata/client/BulkDataObjectResponseTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/BulkDataObjectResponseTests.java
@@ -8,7 +8,17 @@
  */
 package org.opensearch.remote.metadata.client;
 
+import org.opensearch.action.DocWriteRequest;
+import org.opensearch.action.DocWriteResponse.Result;
+import org.opensearch.action.bulk.BulkItemResponse;
+import org.opensearch.action.bulk.BulkResponse;
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.update.UpdateResponse;
+import org.opensearch.common.unit.TimeValue;
+import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.remote.metadata.common.SdkClientUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -18,18 +28,46 @@ import java.util.List;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import static org.opensearch.action.bulk.BulkResponse.NO_INGEST_TOOK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 public class BulkDataObjectResponseTests {
     @Mock
-    XContentParser parser;
+    BulkResponse testBulkResponse;
+
+    private long testTookInMillis;
+    private boolean testHasFailures;
+    private XContentParser testParser;
+    private BulkItemResponse[] testBulkItems;
 
     @BeforeEach
     public void setup() throws IOException {
         MockitoAnnotations.openMocks(this);
+
+        testTookInMillis = 100L;
+        testHasFailures = false;
+
+        ShardId shardId = new ShardId("test-index", "_na_", 1);
+        testBulkItems = new BulkItemResponse[] {
+            new BulkItemResponse(0, DocWriteRequest.OpType.INDEX, new IndexResponse(shardId, "1", 1, 1, 1, true)),
+            new BulkItemResponse(1, DocWriteRequest.OpType.UPDATE, new UpdateResponse(shardId, "2", 1, 1, 1, Result.UPDATED)),
+            new BulkItemResponse(2, DocWriteRequest.OpType.DELETE, new DeleteResponse(shardId, "3", 1, 1, 1, true)) };
+
+        // Setup BulkResponse mock
+        when(testBulkResponse.getTook()).thenReturn(TimeValue.timeValueMillis(testTookInMillis));
+        when(testBulkResponse.hasFailures()).thenReturn(testHasFailures);
+        when(testBulkResponse.getItems()).thenReturn(testBulkItems);
+        when(testBulkResponse.getIngestTookInMillis()).thenReturn(NO_INGEST_TOOK);
+
+        // Create a real parser from a minimal valid bulk response JSON
+        String bulkResponseJson = "{\"took\": 100, \"errors\": false, \"items\": []}";
+        testParser = SdkClientUtils.createParser(bulkResponseJson);
     }
 
     @Test
@@ -40,13 +78,13 @@ public class BulkDataObjectResponseTests {
             DeleteDataObjectResponse.builder().build()
         ).toArray(new DataObjectResponse[0]);
 
-        BulkDataObjectResponse response = new BulkDataObjectResponse(responses, 1L, false, parser);
+        BulkDataObjectResponse response = new BulkDataObjectResponse(responses, 1L, false, testParser);
 
         assertEquals(3, response.getResponses().length);
         assertEquals(1L, response.getTookInMillis());
         assertEquals(-1L, response.getIngestTookInMillis());
         assertFalse(response.hasFailures());
-        assertSame(parser, response.parser());
+        assertSame(testParser, response.parser());
     }
 
     @Test
@@ -56,12 +94,54 @@ public class BulkDataObjectResponseTests {
             DeleteDataObjectResponse.builder().failed(true).build()
         ).toArray(new DataObjectResponse[0]);
 
-        BulkDataObjectResponse response = new BulkDataObjectResponse(responses, 1L, true, parser);
+        BulkDataObjectResponse response = new BulkDataObjectResponse(responses, 1L, true, testParser);
 
         assertEquals(2, response.getResponses().length);
         assertEquals(1L, response.getTookInMillis());
         assertEquals(-1L, response.getIngestTookInMillis());
         assertTrue(response.hasFailures());
-        assertSame(parser, response.parser());
+        assertSame(testParser, response.parser());
+    }
+
+    @Test
+    public void testBulkResponse_FromParser() throws IOException {
+        // Create response with parser
+        DataObjectResponse[] responses = new DataObjectResponse[0];
+        BulkDataObjectResponse response = new BulkDataObjectResponse(responses, 1L, false, testParser);
+
+        BulkResponse parsedResponse = response.bulkResponse();
+        assertNotNull(parsedResponse);
+        assertEquals(100, parsedResponse.getTook().millis());
+        assertFalse(parsedResponse.hasFailures());
+    }
+
+    @Test
+    public void testParser_FromBulkResponse() throws IOException {
+        // Setup mock BulkResponse with proper XContent behavior
+        BulkDataObjectResponse response = new BulkDataObjectResponse(testBulkResponse);
+
+        // Test that we can get a parser
+        XContentParser parser = response.parser();
+        assertNotNull(parser, "Parser should be created from BulkResponse");
+
+        // Test that we can get the bulk response back
+        BulkResponse retrievedResponse = response.bulkResponse();
+        assertNotNull(retrievedResponse);
+        assertEquals(testTookInMillis, retrievedResponse.getTook().millis());
+        assertEquals(testHasFailures, retrievedResponse.hasFailures());
+    }
+
+    @Test
+    public void testParser_NullHandling() {
+        // Test when both parser and bulkResponse are null
+        BulkDataObjectResponse response = new BulkDataObjectResponse(new DataObjectResponse[0], 1L, false, null);
+        assertNull(response.parser());
+    }
+
+    @Test
+    public void testBulkResponse_NullHandling() {
+        // Test when both parser and bulkResponse are null
+        BulkDataObjectResponse response = new BulkDataObjectResponse(new DataObjectResponse[0], 1L, false, null);
+        assertNull(response.bulkResponse());
     }
 }

--- a/core/src/test/java/org/opensearch/remote/metadata/client/DeleteDataObjectResponseTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/DeleteDataObjectResponseTests.java
@@ -8,14 +8,25 @@
  */
 package org.opensearch.remote.metadata.client;
 
+import org.opensearch.OpenSearchException;
+import org.opensearch.action.bulk.BulkItemResponse;
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.index.IndexResponse;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentParser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class DeleteDataObjectResponseTests {
 
@@ -25,6 +36,9 @@ public class DeleteDataObjectResponseTests {
     private boolean testFailed;
     private Exception testCause;
     private RestStatus testStatus;
+    private DeleteResponse testDeleteResponse;
+    private BulkItemResponse testBulkItemResponse;
+    private DeleteResponse testBulkDeleteResponse;
 
     @BeforeEach
     public void setUp() {
@@ -34,10 +48,22 @@ public class DeleteDataObjectResponseTests {
         testFailed = true;
         testCause = mock(RuntimeException.class);
         testStatus = RestStatus.BAD_REQUEST;
+        testDeleteResponse = mock(DeleteResponse.class);
+        when(testDeleteResponse.getIndex()).thenReturn(testIndex);
+        when(testDeleteResponse.getId()).thenReturn(testId);
+
+        testBulkDeleteResponse = mock(DeleteResponse.class);
+        when(testBulkDeleteResponse.getIndex()).thenReturn(testIndex);
+        when(testBulkDeleteResponse.getId()).thenReturn(testId);
+
+        testBulkItemResponse = mock(BulkItemResponse.class);
+        when(testBulkItemResponse.getIndex()).thenReturn(testIndex);
+        when(testBulkItemResponse.getId()).thenReturn(testId);
+        when(testBulkItemResponse.getResponse()).thenReturn(testBulkDeleteResponse);
     }
 
     @Test
-    public void testDeleteDataObjectResponse() {
+    public void testDeleteDataObjectResponseBuilder() {
         DeleteDataObjectResponse response = DeleteDataObjectResponse.builder()
             .index(testIndex)
             .id(testId)
@@ -53,5 +79,65 @@ public class DeleteDataObjectResponseTests {
         assertEquals(testFailed, response.isFailed());
         assertSame(testCause, response.cause());
         assertEquals(testStatus, response.status());
+    }
+
+    @Test
+    public void testDeleteDataObjectResponseWithDeleteResponse() throws IOException {
+        DeleteDataObjectResponse response = new DeleteDataObjectResponse(testDeleteResponse);
+
+        assertEquals(testIndex, response.index());
+        assertEquals(testId, response.id());
+        assertEquals(false, response.isFailed());
+        assertNull(response.cause());
+        assertNull(response.status());
+        assertSame(testDeleteResponse, response.deleteResponse());
+    }
+
+    @Test
+    public void testParserCreationFromDeleteResponse() {
+        DeleteDataObjectResponse response = new DeleteDataObjectResponse(testDeleteResponse);
+        XContentParser parser = response.parser();
+        assertNotNull(parser, "Parser should be created from DeleteResponse");
+    }
+
+    @Test
+    public void testDeleteDataObjectResponse_FromBulkItemResponse() {
+        when(testBulkItemResponse.isFailed()).thenReturn(false);
+        DeleteDataObjectResponse response = new DeleteDataObjectResponse(testBulkItemResponse);
+
+        assertEquals(testIndex, response.index());
+        assertEquals(testId, response.id());
+        assertEquals(false, response.isFailed());
+        assertNull(response.cause());
+        assertNull(response.status());
+        assertSame(testBulkDeleteResponse, response.deleteResponse());
+    }
+
+    @Test
+    public void testDeleteDataObjectResponse_FromFailedBulkItemResponse() {
+        BulkItemResponse.Failure failure = mock(BulkItemResponse.Failure.class);
+        when(failure.getCause()).thenReturn(testCause);
+        when(failure.getStatus()).thenReturn(testStatus);
+
+        when(testBulkItemResponse.isFailed()).thenReturn(true);
+        when(testBulkItemResponse.getFailure()).thenReturn(failure);
+        when(testBulkItemResponse.getResponse()).thenReturn(null);
+
+        DeleteDataObjectResponse response = new DeleteDataObjectResponse(testBulkItemResponse);
+
+        assertEquals(testIndex, response.index());
+        assertEquals(testId, response.id());
+        assertTrue(response.isFailed());
+        assertSame(testCause, response.cause());
+        assertEquals(testStatus, response.status());
+        assertNull(response.deleteResponse());
+    }
+
+    @Test
+    public void testDeleteDataObjectResponse_FromBulkItemResponseWrongType() {
+        IndexResponse wrongResponse = mock(IndexResponse.class);
+        when(testBulkItemResponse.getResponse()).thenReturn(wrongResponse);
+
+        assertThrows(OpenSearchException.class, () -> new DeleteDataObjectResponse(testBulkItemResponse));
     }
 }

--- a/core/src/test/java/org/opensearch/remote/metadata/client/GetDataObjectResponseTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/GetDataObjectResponseTests.java
@@ -8,16 +8,21 @@
  */
 package org.opensearch.remote.metadata.client;
 
+import org.opensearch.action.get.GetResponse;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentParser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class GetDataObjectResponseTests {
 
@@ -28,6 +33,7 @@ public class GetDataObjectResponseTests {
     private Exception testCause;
     private RestStatus testStatus;
     private Map<String, Object> testSource;
+    private GetResponse testGetResponse;
 
     @BeforeEach
     public void setUp() {
@@ -38,6 +44,10 @@ public class GetDataObjectResponseTests {
         testCause = mock(RuntimeException.class);
         testStatus = RestStatus.BAD_REQUEST;
         testSource = Map.of("foo", "bar");
+        testGetResponse = mock(GetResponse.class);
+        when(testGetResponse.getIndex()).thenReturn(testIndex);
+        when(testGetResponse.getId()).thenReturn(testId);
+        when(testGetResponse.getSourceAsMap()).thenReturn(testSource);
     }
 
     @Test
@@ -59,5 +69,26 @@ public class GetDataObjectResponseTests {
         assertSame(testCause, response.cause());
         assertEquals(testStatus, response.status());
         assertEquals(testSource, response.source());
+    }
+
+    @Test
+    public void testGetDataObjectResponseWithGetResponse() throws IOException {
+        GetDataObjectResponse response = new GetDataObjectResponse(testGetResponse);
+
+        assertEquals(testIndex, response.index());
+        assertEquals(testId, response.id());
+        assertEquals(false, response.isFailed());
+        assertNull(response.cause());
+        assertNull(response.status());
+        assertEquals(testSource, response.source());
+        assertSame(testGetResponse, response.getResponse());
+    }
+
+    @Test
+    public void testGetDataObjectResponseWithNullSource() {
+        when(testGetResponse.getSourceAsMap()).thenReturn(null);
+        GetDataObjectResponse response = new GetDataObjectResponse(testGetResponse);
+
+        assertEquals(Collections.emptyMap(), response.source());
     }
 }

--- a/core/src/test/java/org/opensearch/remote/metadata/client/PutDataObjectResponseTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/PutDataObjectResponseTests.java
@@ -8,14 +8,27 @@
  */
 package org.opensearch.remote.metadata.client;
 
+import org.opensearch.OpenSearchException;
+import org.opensearch.action.bulk.BulkItemResponse;
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.core.index.shard.ShardId;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.remote.metadata.common.SdkClientUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class PutDataObjectResponseTests {
 
@@ -25,19 +38,33 @@ public class PutDataObjectResponseTests {
     private boolean testFailed;
     private Exception testCause;
     private RestStatus testStatus;
+    private IndexResponse testIndexResponse;
+    private BulkItemResponse testBulkItemResponse;
+    private IndexResponse testBulkIndexResponse;
 
     @BeforeEach
     public void setUp() {
-        testId = "test-index";
+        testIndex = "test-index";
         testId = "test-id";
         testParser = mock(XContentParser.class);
         testFailed = true;
         testCause = mock(RuntimeException.class);
         testStatus = RestStatus.BAD_REQUEST;
+        testIndexResponse = new IndexResponse(new ShardId(testIndex, "_na_", 0), testId, 1, 1, 1, true);
+
+        testBulkIndexResponse = mock(IndexResponse.class);
+        when(testBulkIndexResponse.getIndex()).thenReturn(testIndex);
+        when(testBulkIndexResponse.getId()).thenReturn(testId);
+
+        testBulkItemResponse = mock(BulkItemResponse.class);
+        when(testBulkItemResponse.getIndex()).thenReturn(testIndex);
+        when(testBulkItemResponse.getId()).thenReturn(testId);
+        when(testBulkItemResponse.getResponse()).thenReturn(testBulkIndexResponse);
+
     }
 
     @Test
-    public void testPutDataObjectResponse() {
+    public void testPutDataObjectResponse_FromBuilder() {
         PutDataObjectResponse response = PutDataObjectResponse.builder()
             .index(testIndex)
             .id(testId)
@@ -53,5 +80,93 @@ public class PutDataObjectResponseTests {
         assertEquals(testFailed, response.isFailed());
         assertSame(testCause, response.cause());
         assertEquals(testStatus, response.status());
+    }
+
+    @Test
+    public void testPutDataObjectResponse_FromIndexResponse() {
+        PutDataObjectResponse response = new PutDataObjectResponse(testIndexResponse);
+
+        assertEquals(testIndex, response.index());
+        assertEquals(testId, response.id());
+        assertNotNull(response.parser());
+    }
+
+    @Test
+    public void testPutDataObjectResponse_IndexResponseGetter() throws IOException {
+        PutDataObjectResponse response = new PutDataObjectResponse(testIndexResponse);
+        IndexResponse retrievedResponse = response.indexResponse();
+
+        assertSame(testIndexResponse, retrievedResponse);
+    }
+
+    @Test
+    public void testPutDataObjectResponse_IndexResponseFromParser() throws IOException {
+        // Create a minimal valid index response JSON
+        String indexResponseJson = "{\n"
+            + "  \"_index\": \""
+            + testIndex
+            + "\",\n"
+            + "  \"_id\": \""
+            + testId
+            + "\",\n"
+            + "  \"_version\": 1,\n"
+            + "  \"result\": \"created\",\n"
+            + "  \"_shards\": {\n"
+            + "    \"total\": 2,\n"
+            + "    \"successful\": 1,\n"
+            + "    \"failed\": 0\n"
+            + "  },\n"
+            + "  \"_seq_no\": 0,\n"
+            + "  \"_primary_term\": 1\n"
+            + "}";
+
+        XContentParser parser = SdkClientUtils.createParser(indexResponseJson);
+        PutDataObjectResponse response = new PutDataObjectResponse(testIndex, testId, parser, false, null, RestStatus.CREATED);
+
+        IndexResponse parsedResponse = response.indexResponse();
+        assertNotNull(parsedResponse);
+        assertEquals(testIndex, parsedResponse.getIndex());
+        assertEquals(testId, parsedResponse.getId());
+    }
+
+    @Test
+    public void testPutDataObjectResponse_FromBulkItemResponse() {
+        when(testBulkItemResponse.isFailed()).thenReturn(false);
+        PutDataObjectResponse response = new PutDataObjectResponse(testBulkItemResponse);
+
+        assertEquals(testIndex, response.index());
+        assertEquals(testId, response.id());
+        assertEquals(false, response.isFailed());
+        assertNull(response.cause());
+        assertNull(response.status());
+        assertSame(testBulkIndexResponse, response.indexResponse());
+    }
+
+    @Test
+    public void testPutDataObjectResponse_FromFailedBulkItemResponse() {
+        BulkItemResponse.Failure failure = mock(BulkItemResponse.Failure.class);
+        when(failure.getCause()).thenReturn(testCause);
+        when(failure.getStatus()).thenReturn(testStatus);
+
+        when(testBulkItemResponse.isFailed()).thenReturn(true);
+        when(testBulkItemResponse.getFailure()).thenReturn(failure);
+        when(testBulkItemResponse.getResponse()).thenReturn(null);
+
+        PutDataObjectResponse response = new PutDataObjectResponse(testBulkItemResponse);
+
+        assertEquals(testIndex, response.index());
+        assertEquals(testId, response.id());
+        assertTrue(response.isFailed());
+        assertSame(testCause, response.cause());
+        assertEquals(testStatus, response.status());
+        assertNull(response.indexResponse());
+    }
+
+    @Test
+    public void testPutDataObjectResponse_FromBulkItemResponseWrongType() {
+        DeleteResponse wrongResponse = mock(DeleteResponse.class);
+        when(testBulkItemResponse.getResponse()).thenReturn(wrongResponse);
+
+        assertThrows(OpenSearchException.class, () -> new PutDataObjectResponse(testBulkItemResponse));
     }
 }

--- a/core/src/test/java/org/opensearch/remote/metadata/client/SearchDataObjectResponseTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/SearchDataObjectResponseTests.java
@@ -8,26 +8,90 @@
  */
 package org.opensearch.remote.metadata.client;
 
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.SearchResponse.Clusters;
+import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.remote.metadata.common.SdkClientUtils;
+import org.opensearch.search.internal.InternalSearchResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
 public class SearchDataObjectResponseTests {
 
     private XContentParser testParser;
+    private SearchResponse testSearchResponse;
 
     @BeforeEach
     public void setUp() {
         testParser = mock(XContentParser.class);
+        testSearchResponse = new SearchResponse(
+            InternalSearchResponse.empty(),
+            null,
+            1,
+            1,
+            0,
+            100L,
+            ShardSearchFailure.EMPTY_ARRAY,
+            Clusters.EMPTY
+        );
     }
 
     @Test
-    public void testSearchDataObjectResponse() {
+    public void testSearchDataObjectResponse_FromParser() throws IOException {
         SearchDataObjectResponse response = SearchDataObjectResponse.builder().parser(testParser).build();
 
         assertEquals(testParser, response.parser());
+    }
+
+    @Test
+    public void testSearchDataObjectResponse_FromSearchResponse() throws IOException {
+        SearchDataObjectResponse response = new SearchDataObjectResponse(testSearchResponse);
+        assertSame(testSearchResponse, response.searchResponse());
+        assertNotNull(response.parser());
+    }
+
+    @Test
+    public void testSearchDataObjectResponse_SearchResponseFromParser() throws IOException {
+        String searchResponseJson = "{\n"
+            + "  \"took\" : 1,\n"
+            + "  \"timed_out\" : false,\n"
+            + "  \"_shards\" : {\n"
+            + "    \"total\" : 1,\n"
+            + "    \"successful\" : 1,\n"
+            + "    \"skipped\" : 0,\n"
+            + "    \"failed\" : 0\n"
+            + "  },\n"
+            + "  \"hits\" : {\n"
+            + "    \"total\" : {\n"
+            + "      \"value\" : 0,\n"
+            + "      \"relation\" : \"eq\"\n"
+            + "    },\n"
+            + "    \"max_score\" : null,\n"
+            + "    \"hits\" : [ ]\n"
+            + "  }\n"
+            + "}";
+
+        XContentParser parser = SdkClientUtils.createParser(searchResponseJson);
+        SearchDataObjectResponse response = new SearchDataObjectResponse(parser);
+        SearchResponse parsedResponse = response.searchResponse();
+        assertNotNull(parsedResponse);
+        assertEquals(1L, parsedResponse.getTook().millis());
+        assertFalse(parsedResponse.isTimedOut());
+    }
+
+    @Test
+    public void testBuilder_Empty() {
+        // Builder should work with no parameters set
+        SearchDataObjectResponse response = SearchDataObjectResponse.builder().build();
+        assertNotNull(response);
     }
 }

--- a/core/src/test/java/org/opensearch/remote/metadata/client/UpdateDataObjectResponseTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/UpdateDataObjectResponseTests.java
@@ -8,14 +8,25 @@
  */
 package org.opensearch.remote.metadata.client;
 
+import org.opensearch.OpenSearchException;
+import org.opensearch.action.bulk.BulkItemResponse;
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentParser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class UpdateDataObjectResponseTests {
 
@@ -25,6 +36,9 @@ public class UpdateDataObjectResponseTests {
     private boolean testFailed;
     private Exception testCause;
     private RestStatus testStatus;
+    private UpdateResponse testUpdateResponse;
+    private BulkItemResponse testBulkItemResponse;
+    private UpdateResponse testBulkUpdateResponse;
 
     @BeforeEach
     public void setUp() {
@@ -34,11 +48,22 @@ public class UpdateDataObjectResponseTests {
         testFailed = true;
         testCause = mock(RuntimeException.class);
         testStatus = RestStatus.BAD_REQUEST;
+        testUpdateResponse = mock(UpdateResponse.class);
+        when(testUpdateResponse.getIndex()).thenReturn(testIndex);
+        when(testUpdateResponse.getId()).thenReturn(testId);
 
+        testBulkUpdateResponse = mock(UpdateResponse.class);
+        when(testBulkUpdateResponse.getIndex()).thenReturn(testIndex);
+        when(testBulkUpdateResponse.getId()).thenReturn(testId);
+
+        testBulkItemResponse = mock(BulkItemResponse.class);
+        when(testBulkItemResponse.getIndex()).thenReturn(testIndex);
+        when(testBulkItemResponse.getId()).thenReturn(testId);
+        when(testBulkItemResponse.getResponse()).thenReturn(testBulkUpdateResponse);
     }
 
     @Test
-    public void testUpdateDataObjectResponse() {
+    public void testUpdateDataObjectResponseBuilder() {
         UpdateDataObjectResponse response = UpdateDataObjectResponse.builder()
             .index(testIndex)
             .id(testId)
@@ -54,5 +79,66 @@ public class UpdateDataObjectResponseTests {
         assertEquals(testFailed, response.isFailed());
         assertSame(testCause, response.cause());
         assertEquals(testStatus, response.status());
+    }
+
+    @Test
+    public void testUpdateDataObjectResponseWithUpdateResponse() throws IOException {
+        UpdateDataObjectResponse response = new UpdateDataObjectResponse(testUpdateResponse);
+
+        assertEquals(testIndex, response.index());
+        assertEquals(testId, response.id());
+        assertNotNull(response.parser()); // Parser is created from UpdateResponse
+        assertEquals(false, response.isFailed());
+        assertNull(response.cause());
+        assertNull(response.status());
+        assertSame(testUpdateResponse, response.updateResponse());
+    }
+
+    @Test
+    public void testParserCreationFromUpdateResponse() {
+        UpdateDataObjectResponse response = new UpdateDataObjectResponse(testUpdateResponse);
+        XContentParser parser = response.parser();
+        assertNotNull(parser);
+    }
+
+    @Test
+    public void testUpdateDataObjectResponse_FromBulkItemResponse() {
+        when(testBulkItemResponse.isFailed()).thenReturn(false);
+        UpdateDataObjectResponse response = new UpdateDataObjectResponse(testBulkItemResponse);
+
+        assertEquals(testIndex, response.index());
+        assertEquals(testId, response.id());
+        assertEquals(false, response.isFailed());
+        assertNull(response.cause());
+        assertNull(response.status());
+        assertSame(testBulkUpdateResponse, response.updateResponse());
+    }
+
+    @Test
+    public void testUpdateDataObjectResponse_FromFailedBulkItemResponse() {
+        BulkItemResponse.Failure failure = mock(BulkItemResponse.Failure.class);
+        when(failure.getCause()).thenReturn(testCause);
+        when(failure.getStatus()).thenReturn(testStatus);
+
+        when(testBulkItemResponse.isFailed()).thenReturn(true);
+        when(testBulkItemResponse.getFailure()).thenReturn(failure);
+        when(testBulkItemResponse.getResponse()).thenReturn(null);
+
+        UpdateDataObjectResponse response = new UpdateDataObjectResponse(testBulkItemResponse);
+
+        assertEquals(testIndex, response.index());
+        assertEquals(testId, response.id());
+        assertTrue(response.isFailed());
+        assertSame(testCause, response.cause());
+        assertEquals(testStatus, response.status());
+        assertNull(response.updateResponse());
+    }
+
+    @Test
+    public void testUpdateDataObjectResponse_FromBulkItemResponseWrongType() {
+        DeleteResponse wrongResponse = mock(DeleteResponse.class);
+        when(testBulkItemResponse.getResponse()).thenReturn(wrongResponse);
+
+        assertThrows(OpenSearchException.class, () -> new UpdateDataObjectResponse(testBulkItemResponse));
     }
 }

--- a/core/src/test/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClientTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClientTests.java
@@ -79,7 +79,6 @@ import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedTok
 import static org.opensearch.remote.metadata.common.CommonValue.TENANT_ID_FIELD_KEY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -223,26 +222,6 @@ public class LocalClusterIndicesClientTests {
         );
         ensureExpectedToken(XContentParser.Token.START_OBJECT, dataParser.nextToken(), dataParser);
         assertEquals("foo", TestDataObject.parse(dataParser).data());
-    }
-
-    @Test
-    public void testGetDataObject_NullResponse() throws IOException {
-        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).tenantId(TEST_TENANT_ID).build();
-
-        doAnswer(invocation -> {
-            ActionListener<GetResponse> listener = invocation.getArgument(1);
-            listener.onResponse(null);
-            return null;
-        }).when(mockedClient).get(any(GetRequest.class), any());
-
-        GetDataObjectResponse response = sdkClient.getDataObjectAsync(getRequest).toCompletableFuture().join();
-
-        ArgumentCaptor<GetRequest> requestCaptor = ArgumentCaptor.forClass(GetRequest.class);
-        verify(mockedClient, times(1)).get(requestCaptor.capture(), any());
-        assertEquals(TEST_INDEX, requestCaptor.getValue().index());
-        assertEquals(TEST_ID, response.id());
-        assertNull(response.parser());
-        assertTrue(response.source().isEmpty());
     }
 
     @Test
@@ -398,30 +377,6 @@ public class LocalClusterIndicesClientTests {
         assertEquals(0, updateActionResponse.getShardInfo().getFailed());
         assertEquals(1, updateActionResponse.getShardInfo().getSuccessful());
         assertEquals(1, updateActionResponse.getShardInfo().getTotal());
-    }
-
-    @Test
-    public void testUpdateDataObject_Null() throws IOException {
-        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest.builder()
-            .index(TEST_INDEX)
-            .id(TEST_ID)
-            .tenantId(TEST_TENANT_ID)
-            .dataObject(testDataObject)
-            .build();
-
-        doAnswer(invocation -> {
-            ActionListener<UpdateResponse> listener = invocation.getArgument(1);
-            listener.onResponse(null);
-            return null;
-        }).when(mockedClient).update(any(UpdateRequest.class), any());
-
-        UpdateDataObjectResponse response = sdkClient.updateDataObjectAsync(updateRequest).toCompletableFuture().join();
-
-        ArgumentCaptor<UpdateRequest> requestCaptor = ArgumentCaptor.forClass(UpdateRequest.class);
-        verify(mockedClient, times(1)).update(requestCaptor.capture(), any());
-        assertEquals(TEST_INDEX, requestCaptor.getValue().index());
-        assertEquals(TEST_ID, response.id());
-        assertNull(response.parser());
     }
 
     @Test
@@ -646,7 +601,7 @@ public class LocalClusterIndicesClientTests {
                 new BulkItemResponse(
                     0,
                     OpType.DELETE,
-                    new IndexResponse(new ShardId(TEST_INDEX, "_na_", 0), TEST_ID + "3", 1, 1, 1, true)
+                    new DeleteResponse(new ShardId(TEST_INDEX, "_na_", 0), TEST_ID + "3", 1, 1, 1, true)
                 ) },
             100L
         );

--- a/remote-client/src/main/java/org/opensearch/remote/metadata/client/impl/RemoteClusterIndicesClient.java
+++ b/remote-client/src/main/java/org/opensearch/remote/metadata/client/impl/RemoteClusterIndicesClient.java
@@ -55,7 +55,6 @@ import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.common.Strings;
 import org.opensearch.core.rest.RestStatus;
-import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -96,7 +95,6 @@ import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 
 import static org.opensearch.common.util.concurrent.ThreadContextAccess.doPrivileged;
-import static org.opensearch.common.xcontent.json.JsonXContent.jsonXContent;
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_OPENSEARCH;
 import static org.opensearch.remote.metadata.common.CommonValue.TENANT_ID_FIELD_KEY;
 
@@ -564,7 +562,7 @@ public class RemoteClusterIndicesClient extends AbstractSdkClient {
         try (JsonGenerator generator = mapper.jsonProvider().createGenerator(stringWriter)) {
             mapper.serialize(obj, generator);
         }
-        return jsonXContent.createParser(NamedXContentRegistry.EMPTY, DeprecationHandler.IGNORE_DEPRECATIONS, stringWriter.toString());
+        return SdkClientUtils.createParser(stringWriter.toString());
     }
 
     /**


### PR DESCRIPTION
WIP: Still need to address bulk response

### Description

Avoids the serializing and deserializing of responses in the (default) client.  This avoids parsing issues as well as loss of runtime information of subclasses.

### Issues Resolved

Alternate solution to resolve #132 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
