### PR TITLE
Using java-agent gradle plugin to phase off Security Manager in favor of Java-agent.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ allprojects {
     apply plugin: 'jacoco'
     apply plugin: 'com.diffplug.spotless'
     apply plugin: 'checkstyle'
+    apply plugin: 'opensearch.java-agent'
 
     repositories {
         mavenLocal()

--- a/build.gradle
+++ b/build.gradle
@@ -76,16 +76,6 @@ allprojects {
         toolVersion = "latest.release"
     }
 
-    configurations {
-        agent
-    }
-
-    dependencies {
-        agent "org.opensearch:opensearch-agent-bootstrap:${opensearch_version}"
-        agent "org.opensearch:opensearch-agent:${opensearch_version}"
-        agent "net.bytebuddy:byte-buddy:${versions.bytebuddy}"
-    }
-
 }
 
 subprojects {
@@ -231,14 +221,4 @@ task updateVersion {
         println "Setting version to ${newVersion}."
         ant.replaceregexp(file:'build.gradle', match: '"opensearch.version", "\\d.*"', replace: '"opensearch.version", "' + newVersion.tokenize('-')[0] + '-SNAPSHOT"', flags:'g', byline:true)
     }
-}
-
-task prepareAgent(type: Copy) {
-  from(configurations.agent)
-  into "$buildDir/agent"
-}
-
-tasks.withType(Test) {
-    dependsOn prepareAgent
-    jvmArgs += ["-javaagent:" + project.layout.buildDirectory.file("agent/opensearch-agent-${opensearch_version}.jar").get()]
 }


### PR DESCRIPTION
### Description
Using java-agent gradle plugin to phase off Security Manager in favor of Java-agent.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
