### PR TITLE
Make generated responses robust to URL encoded id and index values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@ All notable changes to this project are documented in this file.
 
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
-## [Unreleased 3.0](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/compare/2.x...HEAD)
+## [Unreleased 3.0](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/compare/3.0...HEAD)
 ### Features
 ### Enhancements
 ### Bug Fixes
 - Directly return responses from Local Cluster client ([#141](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/141))
+- Make generated responses robust to URL encoded id and index values ([#156](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/156))
 - Properly handle remote client search failures with status codes ([#158](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/158))
 
 ### Infrastructure

--- a/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClient.java
+++ b/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClient.java
@@ -8,7 +8,7 @@
  */
 package org.opensearch.remote.metadata.client.impl;
 
-import com.fasterxml.jackson.core.io.JsonStringEncoder;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -74,6 +74,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -191,14 +192,14 @@ public class DDBOpenSearchClient extends AbstractSdkClient {
                 final PutItemRequest putItemRequest = builder.build();
 
                 return dynamoDbAsyncClient.putItem(putItemRequest).thenApply(putItemResponse -> {
-                    String simulatedIndexResponse = simulateOpenSearchResponse(
-                        request.index(),
-                        id,
-                        source,
-                        sequenceNumber,
-                        Map.of("result", "created")
-                    );
                     try {
+                        String simulatedIndexResponse = simulateOpenSearchResponse(
+                            request.index(),
+                            id,
+                            source,
+                            sequenceNumber,
+                            Map.of("result", "created")
+                        );
                         return PutDataObjectResponse.builder().id(id).parser(SdkClientUtils.createParser(simulatedIndexResponse)).build();
                     } catch (IOException e) {
                         throw new OpenSearchStatusException("Failed to create parser for response", RestStatus.INTERNAL_SERVER_ERROR, e);
@@ -619,39 +620,25 @@ public class DDBOpenSearchClient extends AbstractSdkClient {
         String source,
         Long sequenceNumber,
         Map<String, Object> additionalFields
-    ) {
-        Long seqNo = UNASSIGNED_SEQ_NO;
-        Long primaryTerm = UNASSIGNED_PRIMARY_TERM;
-        if (sequenceNumber != null) {
-            seqNo = sequenceNumber;
-            primaryTerm = DEFAULT_PRIMARY_TERM;
+    ) throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("_index", index);
+        response.put("_id", id);
+        if (sequenceNumber == null) {
+            response.put("_primary_term", UNASSIGNED_PRIMARY_TERM);
+            response.put("_seq_no", UNASSIGNED_SEQ_NO);
+        } else {
+            response.put("_primary_term", DEFAULT_PRIMARY_TERM);
+            response.put("_seq_no", sequenceNumber);
         }
-        StringBuilder sb = new StringBuilder("{");
-        // Fields with a DDB counterpart
-        JsonStringEncoder encoder = JsonStringEncoder.getInstance();
-        sb.append("\"_index\":\"").append(new String(encoder.quoteAsString(index))).append("\",");
-        sb.append("\"_id\":\"").append(new String(encoder.quoteAsString(id))).append("\",");
-        // Fields we must simulate using default values
-        sb.append("\"_primary_term\":").append(primaryTerm).append(",");
-        sb.append("\"_seq_no\":").append(seqNo).append(",");
-        sb.append("\"_version\":").append(-1).append(",");
-        sb.append("\"_shards\":").append(Strings.toString(MediaTypeRegistry.JSON, new ShardInfo())).append(",");
-        // Finish up
-        additionalFields.entrySet()
-            .stream()
-            .forEach(
-                e -> sb.append("\"")
-                    .append(new String(encoder.quoteAsString(e.getKey())))
-                    .append("\":")
-                    .append(
-                        e.getValue() instanceof String
-                            ? ("\"" + new String(encoder.quoteAsString(e.getValue().toString())) + "\"")
-                            : e.getValue()
-                    )
-                    .append(",")
-            );
-        sb.append("\"_source\":").append(source).append("}");
-        return sb.toString();
+        response.put("_version", -1);
+        response.put("_shards", new ShardInfo());
+        response.putAll(additionalFields);
+        if (source != null) {
+            response.put("_source", mapper.readTree(source));
+        }
+        return mapper.writeValueAsString(response);
     }
 
     private static void validateAwsParams(String clientType, String remoteMetadataEndpoint, String region, String serviceName) {


### PR DESCRIPTION
### Description

Properly handles URL-encoded strings for ID and Index passed through to response

### Issues Resolved

Part of #154.

Related: 
- [x] request length validation https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/157
- [x] search request body validation https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/158

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
