### PR TITLE
Validate request fields in DDB Put and Update implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Bug Fixes
 - Directly return responses from Local Cluster client ([#141](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/141))
 - Make generated responses robust to URL encoded id and index values ([#156](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/156))
+- Validate request fields in DDB Put and Update implementations ([#157](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/157))
 - Properly handle remote client search failures with status codes ([#158](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/158))
 
 ### Infrastructure

--- a/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClient.java
+++ b/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClient.java
@@ -33,14 +33,17 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchException;
 import org.opensearch.OpenSearchStatusException;
+import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.action.DocWriteRequest.OpType;
 import org.opensearch.action.DocWriteResponse;
 import org.opensearch.action.bulk.BulkItemResponse;
 import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.get.GetResponse;
+import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.replication.ReplicationResponse.ShardInfo;
+import org.opensearch.action.update.UpdateRequest;
 import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentFactory;
@@ -162,6 +165,18 @@ public class DDBOpenSearchClient extends AbstractSdkClient {
         Boolean isMultiTenancyEnabled
     ) {
         final String id = request.id() != null ? request.id() : UUID.randomUUID().toString();
+        // Validate parameters and data object body
+        try (XContentBuilder sourceBuilder = XContentFactory.jsonBuilder()) {
+            IndexRequest indexRequest = new IndexRequest(request.index()).opType(request.overwriteIfExists() ? OpType.INDEX : OpType.CREATE)
+                .source(request.dataObject().toXContent(sourceBuilder, ToXContent.EMPTY_PARAMS));
+            indexRequest.id(id);
+            ActionRequestValidationException validationException = indexRequest.validate();
+            if (validationException != null) {
+                throw new OpenSearchStatusException(validationException.getMessage(), RestStatus.BAD_REQUEST);
+            }
+        } catch (IOException e) {
+            throw new OpenSearchStatusException("Request body validation failed.", RestStatus.BAD_REQUEST, e);
+        }
         final String tenantId = request.tenantId() != null ? request.tenantId() : DEFAULT_TENANT;
         final String tableName = request.index();
         final GetItemRequest getItemRequest = buildGetItemRequest(tenantId, id, request.index());
@@ -281,6 +296,28 @@ public class DDBOpenSearchClient extends AbstractSdkClient {
         Executor executor,
         Boolean isMultiTenancyEnabled
     ) {
+        // Validate parameters and data object body
+        try (XContentBuilder sourceBuilder = XContentFactory.jsonBuilder()) {
+            UpdateRequest updateRequest = new UpdateRequest(request.index(), request.id()).doc(
+                request.dataObject().toXContent(sourceBuilder, ToXContent.EMPTY_PARAMS)
+            );
+
+            if (request.ifSeqNo() != null) {
+                updateRequest.setIfSeqNo(request.ifSeqNo());
+            }
+            if (request.ifPrimaryTerm() != null) {
+                updateRequest.setIfPrimaryTerm(request.ifPrimaryTerm());
+            }
+            if (request.retryOnConflict() > 0) {
+                updateRequest.retryOnConflict(request.retryOnConflict());
+            }
+            ActionRequestValidationException validationException = updateRequest.validate();
+            if (validationException != null) {
+                throw new OpenSearchStatusException(validationException.getMessage(), RestStatus.BAD_REQUEST);
+            }
+        } catch (IOException e) {
+            throw new OpenSearchStatusException("Request body validation failed.", RestStatus.BAD_REQUEST, e);
+        }
         final String tenantId = request.tenantId() != null ? request.tenantId() : DEFAULT_TENANT;
         return doPrivileged(() -> {
             try {

--- a/ddb-client/src/test/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClientTests.java
+++ b/ddb-client/src/test/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClientTests.java
@@ -36,6 +36,8 @@ import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.remote.metadata.client.BulkDataObjectRequest;
 import org.opensearch.remote.metadata.client.BulkDataObjectResponse;
@@ -304,6 +306,46 @@ public class DDBOpenSearchClientTests {
 
         CompletionException ce = assertThrows(CompletionException.class, () -> future.join());
         assertEquals(RuntimeException.class, ce.getCause().getClass());
+    }
+
+    @Test
+    public void testPutDataObject_InvalidId_ThrowsBadRequest() {
+        String longId = String.join("", Collections.nCopies(513, "a"));
+        PutDataObjectRequest putRequest = PutDataObjectRequest.builder()
+            .index(TEST_INDEX)
+            .id(longId)
+            .tenantId(TENANT_ID)
+            .dataObject(testDataObject)
+            .build();
+        OpenSearchStatusException ose = assertThrows(
+            OpenSearchStatusException.class,
+            () -> sdkClient.putDataObjectAsync(putRequest, testThreadPool.executor(TEST_THREAD_POOL))
+        );
+        assertEquals(RestStatus.BAD_REQUEST, ose.status());
+        assertTrue(ose.getMessage().contains("is too long, must be no longer than 512 bytes but was: 513"));
+    }
+
+    @Test
+    public void testPutDataObject_InvalidDataObject_ThrowsBadRequest() {
+        ToXContentObject invalidDataObject = new ToXContentObject() {
+            public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+                throw new IOException("Test IOException");
+            }
+        };
+        PutDataObjectRequest putRequest = PutDataObjectRequest.builder()
+            .index(TEST_INDEX)
+            .id(TEST_ID)
+            .tenantId(TENANT_ID)
+            .dataObject(invalidDataObject)
+            .build();
+        OpenSearchStatusException ose = assertThrows(
+            OpenSearchStatusException.class,
+            () -> sdkClient.putDataObjectAsync(putRequest, testThreadPool.executor(TEST_THREAD_POOL))
+        );
+        assertEquals(RestStatus.BAD_REQUEST, ose.status());
+        assertEquals("Request body validation failed.", ose.getMessage());
+        assertTrue(ose.getCause() instanceof IOException);
+        assertEquals("Test IOException", ose.getCause().getMessage());
     }
 
     @Test
@@ -678,6 +720,45 @@ public class DDBOpenSearchClientTests {
         Throwable cause = ce.getCause();
         assertEquals(OpenSearchStatusException.class, cause.getClass());
         assertEquals(RestStatus.CONFLICT, ((OpenSearchStatusException) cause).status());
+    }
+
+    @Test
+    public void testUpdateDataObject_MissingId_ThrowsBadRequest() {
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest.builder()
+            .index(TEST_INDEX)
+            .id(null)  // Missing ID
+            .tenantId(TENANT_ID)
+            .dataObject(testDataObject)
+            .build();
+        OpenSearchStatusException ose = assertThrows(
+            OpenSearchStatusException.class,
+            () -> sdkClient.updateDataObjectAsync(updateRequest, testThreadPool.executor(TEST_THREAD_POOL))
+        );
+        assertEquals(RestStatus.BAD_REQUEST, ose.status());
+        assertTrue(ose.getMessage().contains("id is missing"));
+    }
+
+    @Test
+    public void testUpdateDataObject_InvalidDataObject_ThrowsBadRequest() {
+        ToXContentObject invalidDataObject = new ToXContentObject() {
+            public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+                throw new IOException("Test IOException");
+            }
+        };
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest.builder()
+            .index(TEST_INDEX)
+            .id(TEST_ID)
+            .tenantId(TENANT_ID)
+            .dataObject(invalidDataObject)
+            .build();
+        OpenSearchStatusException ose = assertThrows(
+            OpenSearchStatusException.class,
+            () -> sdkClient.updateDataObjectAsync(updateRequest, testThreadPool.executor(TEST_THREAD_POOL))
+        );
+        assertEquals(RestStatus.BAD_REQUEST, ose.status());
+        assertEquals("Request body validation failed.", ose.getMessage());
+        assertTrue(ose.getCause() instanceof IOException);
+        assertEquals("Test IOException", ose.getCause().getMessage());
     }
 
     @Test


### PR DESCRIPTION
### Description

Validates index, id, and data object fields in put and update requests

### Issues Resolved

Fixes #154 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
