### PR TITLE
Properly handle remote client search failures with status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Enhancements
 ### Bug Fixes
 - Directly return responses from Local Cluster client ([#141](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/141))
+- Properly handle remote client search failures with status codes ([#158](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/158))
 
 ### Infrastructure
 ### Documentation

--- a/core/src/main/java/org/opensearch/remote/metadata/common/SdkClientUtils.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/common/SdkClientUtils.java
@@ -31,6 +31,49 @@ import org.opensearch.core.xcontent.MediaTypeRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.BoostingQueryBuilder;
+import org.opensearch.index.query.ConstantScoreQueryBuilder;
+import org.opensearch.index.query.DisMaxQueryBuilder;
+import org.opensearch.index.query.DistanceFeatureQueryBuilder;
+import org.opensearch.index.query.ExistsQueryBuilder;
+import org.opensearch.index.query.FieldMaskingSpanQueryBuilder;
+import org.opensearch.index.query.FuzzyQueryBuilder;
+import org.opensearch.index.query.GeoBoundingBoxQueryBuilder;
+import org.opensearch.index.query.GeoDistanceQueryBuilder;
+import org.opensearch.index.query.GeoPolygonQueryBuilder;
+import org.opensearch.index.query.GeoShapeQueryBuilder;
+import org.opensearch.index.query.IdsQueryBuilder;
+import org.opensearch.index.query.IntervalQueryBuilder;
+import org.opensearch.index.query.MatchAllQueryBuilder;
+import org.opensearch.index.query.MatchBoolPrefixQueryBuilder;
+import org.opensearch.index.query.MatchNoneQueryBuilder;
+import org.opensearch.index.query.MatchPhrasePrefixQueryBuilder;
+import org.opensearch.index.query.MatchPhraseQueryBuilder;
+import org.opensearch.index.query.MatchQueryBuilder;
+import org.opensearch.index.query.MoreLikeThisQueryBuilder;
+import org.opensearch.index.query.MultiMatchQueryBuilder;
+import org.opensearch.index.query.NestedQueryBuilder;
+import org.opensearch.index.query.PrefixQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.index.query.QueryStringQueryBuilder;
+import org.opensearch.index.query.RangeQueryBuilder;
+import org.opensearch.index.query.RegexpQueryBuilder;
+import org.opensearch.index.query.ScriptQueryBuilder;
+import org.opensearch.index.query.SimpleQueryStringBuilder;
+import org.opensearch.index.query.SpanContainingQueryBuilder;
+import org.opensearch.index.query.SpanFirstQueryBuilder;
+import org.opensearch.index.query.SpanNearQueryBuilder;
+import org.opensearch.index.query.SpanNotQueryBuilder;
+import org.opensearch.index.query.SpanOrQueryBuilder;
+import org.opensearch.index.query.SpanTermQueryBuilder;
+import org.opensearch.index.query.SpanWithinQueryBuilder;
+import org.opensearch.index.query.TemplateQueryBuilder;
+import org.opensearch.index.query.TermQueryBuilder;
+import org.opensearch.index.query.TermsQueryBuilder;
+import org.opensearch.index.query.TermsSetQueryBuilder;
+import org.opensearch.index.query.WildcardQueryBuilder;
+import org.opensearch.index.query.WrapperQueryBuilder;
 import org.opensearch.remote.metadata.client.BulkDataObjectResponse;
 import org.opensearch.remote.metadata.client.DeleteDataObjectResponse;
 import org.opensearch.remote.metadata.client.GetDataObjectResponse;
@@ -436,7 +479,61 @@ public class SdkClientUtils {
     }
 
     private static List<NamedXContentRegistry.Entry> getDefaultNamedXContents() {
-        Map<String, ContextParser<Object, ? extends Aggregation>> map = Map.ofEntries(
+        List<NamedXContentRegistry.Entry> entries = new ArrayList<>();
+
+        Map<String, ContextParser<Object, ? extends QueryBuilder>> queryMap = Map.ofEntries(
+            Map.entry(BoolQueryBuilder.NAME, (p, c) -> BoolQueryBuilder.fromXContent(p)),
+            Map.entry(BoostingQueryBuilder.NAME, (p, c) -> BoostingQueryBuilder.fromXContent(p)),
+            Map.entry(ConstantScoreQueryBuilder.NAME, (p, c) -> ConstantScoreQueryBuilder.fromXContent(p)),
+            Map.entry(DisMaxQueryBuilder.NAME, (p, c) -> DisMaxQueryBuilder.fromXContent(p)),
+            Map.entry(DistanceFeatureQueryBuilder.NAME, (p, c) -> DistanceFeatureQueryBuilder.fromXContent(p)),
+            Map.entry(ExistsQueryBuilder.NAME, (p, c) -> ExistsQueryBuilder.fromXContent(p)),
+            Map.entry(FieldMaskingSpanQueryBuilder.NAME, (p, c) -> FieldMaskingSpanQueryBuilder.fromXContent(p)),
+            Map.entry(FuzzyQueryBuilder.NAME, (p, c) -> FuzzyQueryBuilder.fromXContent(p)),
+            Map.entry(GeoBoundingBoxQueryBuilder.NAME, (p, c) -> GeoBoundingBoxQueryBuilder.fromXContent(p)),
+            Map.entry(GeoDistanceQueryBuilder.NAME, (p, c) -> GeoDistanceQueryBuilder.fromXContent(p)),
+            Map.entry(GeoPolygonQueryBuilder.NAME, (p, c) -> GeoPolygonQueryBuilder.fromXContent(p)),
+            Map.entry(GeoShapeQueryBuilder.NAME, (p, c) -> GeoShapeQueryBuilder.fromXContent(p)),
+            Map.entry(IdsQueryBuilder.NAME, (p, c) -> IdsQueryBuilder.fromXContent(p)),
+            Map.entry(IntervalQueryBuilder.NAME, (p, c) -> IntervalQueryBuilder.fromXContent(p)),
+            Map.entry(MatchAllQueryBuilder.NAME, (p, c) -> MatchAllQueryBuilder.fromXContent(p)),
+            Map.entry(MatchBoolPrefixQueryBuilder.NAME, (p, c) -> MatchBoolPrefixQueryBuilder.fromXContent(p)),
+            Map.entry(MatchNoneQueryBuilder.NAME, (p, c) -> MatchNoneQueryBuilder.fromXContent(p)),
+            Map.entry(MatchPhrasePrefixQueryBuilder.NAME, (p, c) -> MatchPhrasePrefixQueryBuilder.fromXContent(p)),
+            Map.entry(MatchPhraseQueryBuilder.NAME, (p, c) -> MatchPhraseQueryBuilder.fromXContent(p)),
+            Map.entry(MatchQueryBuilder.NAME, (p, c) -> MatchQueryBuilder.fromXContent(p)),
+            Map.entry(MoreLikeThisQueryBuilder.NAME, (p, c) -> MoreLikeThisQueryBuilder.fromXContent(p)),
+            Map.entry(MultiMatchQueryBuilder.NAME, (p, c) -> MultiMatchQueryBuilder.fromXContent(p)),
+            Map.entry(NestedQueryBuilder.NAME, (p, c) -> NestedQueryBuilder.fromXContent(p)),
+            Map.entry(PrefixQueryBuilder.NAME, (p, c) -> PrefixQueryBuilder.fromXContent(p)),
+            Map.entry(QueryStringQueryBuilder.NAME, (p, c) -> QueryStringQueryBuilder.fromXContent(p)),
+            Map.entry(RangeQueryBuilder.NAME, (p, c) -> RangeQueryBuilder.fromXContent(p)),
+            Map.entry(RegexpQueryBuilder.NAME, (p, c) -> RegexpQueryBuilder.fromXContent(p)),
+            Map.entry(ScriptQueryBuilder.NAME, (p, c) -> ScriptQueryBuilder.fromXContent(p)),
+            Map.entry(SimpleQueryStringBuilder.NAME, (p, c) -> SimpleQueryStringBuilder.fromXContent(p)),
+            Map.entry(SpanContainingQueryBuilder.NAME, (p, c) -> SpanContainingQueryBuilder.fromXContent(p)),
+            Map.entry(SpanFirstQueryBuilder.NAME, (p, c) -> SpanFirstQueryBuilder.fromXContent(p)),
+            Map.entry(SpanNearQueryBuilder.NAME, (p, c) -> SpanNearQueryBuilder.fromXContent(p)),
+            Map.entry(SpanNotQueryBuilder.NAME, (p, c) -> SpanNotQueryBuilder.fromXContent(p)),
+            Map.entry(SpanOrQueryBuilder.NAME, (p, c) -> SpanOrQueryBuilder.fromXContent(p)),
+            Map.entry(SpanTermQueryBuilder.NAME, (p, c) -> SpanTermQueryBuilder.fromXContent(p)),
+            Map.entry(SpanWithinQueryBuilder.NAME, (p, c) -> SpanWithinQueryBuilder.fromXContent(p)),
+            Map.entry(TemplateQueryBuilder.NAME, (p, c) -> TemplateQueryBuilder.fromXContent(p)),
+            Map.entry(TermQueryBuilder.NAME, (p, c) -> TermQueryBuilder.fromXContent(p)),
+            Map.entry(TermsQueryBuilder.NAME, (p, c) -> TermsQueryBuilder.fromXContent(p)),
+            Map.entry(TermsSetQueryBuilder.NAME, (p, c) -> TermsSetQueryBuilder.fromXContent(p)),
+            Map.entry(WildcardQueryBuilder.NAME, (p, c) -> WildcardQueryBuilder.fromXContent(p)),
+            Map.entry(WrapperQueryBuilder.NAME, (p, c) -> WrapperQueryBuilder.fromXContent(p))
+        );
+
+        entries.addAll(
+            queryMap.entrySet()
+                .stream()
+                .map(entry -> new NamedXContentRegistry.Entry(QueryBuilder.class, new ParseField(entry.getKey()), entry.getValue()))
+                .collect(Collectors.toList())
+        );
+
+        Map<String, ContextParser<Object, ? extends Aggregation>> aggMap = Map.ofEntries(
             Map.entry(AvgAggregationBuilder.NAME, (p, c) -> ParsedAvg.fromXContent(p, (String) c)),
             Map.entry(WeightedAvgAggregationBuilder.NAME, (p, c) -> ParsedWeightedAvg.fromXContent(p, (String) c)),
             Map.entry(SumAggregationBuilder.NAME, (p, c) -> ParsedSum.fromXContent(p, (String) c)),
@@ -485,10 +582,14 @@ public class SdkClientUtils {
             Map.entry(ExtendedStatsBucketPipelineAggregationBuilder.NAME, (p, c) -> ParsedExtendedStatsBucket.fromXContent(p, (String) c))
         );
 
-        List<NamedXContentRegistry.Entry> entries = map.entrySet()
-            .stream()
-            .map((entry) -> new NamedXContentRegistry.Entry(Aggregation.class, new ParseField((String) entry.getKey()), entry.getValue()))
-            .collect(Collectors.toList());
+        entries.addAll(
+            aggMap.entrySet()
+                .stream()
+                .map(
+                    (entry) -> new NamedXContentRegistry.Entry(Aggregation.class, new ParseField((String) entry.getKey()), entry.getValue())
+                )
+                .collect(Collectors.toList())
+        );
         return entries;
     }
 }

--- a/remote-client/src/test/java/org/opensearch/remote/metadata/client/impl/RemoteClusterIndicesClientTests.java
+++ b/remote-client/src/test/java/org/opensearch/remote/metadata/client/impl/RemoteClusterIndicesClientTests.java
@@ -12,8 +12,13 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 
+import org.apache.lucene.search.join.ScoreMode;
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.DocWriteResponse;
+import org.opensearch.action.search.SearchPhaseExecutionException;
+import org.opensearch.action.search.ShardSearchFailure;
+import org.opensearch.client.json.JsonData;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch._types.ErrorCause;
@@ -47,9 +52,15 @@ import org.opensearch.common.util.concurrent.OpenSearchExecutors;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.index.Index;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.query.BoolQueryBuilder;
+import org.opensearch.index.query.MatchQueryBuilder;
+import org.opensearch.index.query.NestedQueryBuilder;
+import org.opensearch.index.query.QueryShardContext;
+import org.opensearch.index.query.QueryShardException;
 import org.opensearch.remote.metadata.client.BulkDataObjectRequest;
 import org.opensearch.remote.metadata.client.BulkDataObjectResponse;
 import org.opensearch.remote.metadata.client.DeleteDataObjectRequest;
@@ -75,9 +86,12 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import org.mockito.ArgumentCaptor;
@@ -92,6 +106,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -866,5 +881,66 @@ public class RemoteClusterIndicesClientTests {
         cause = ce.getCause();
         assertEquals(UnsupportedOperationException.class, cause.getClass());
         assertEquals("test", cause.getMessage());
+    }
+
+    @Test
+    public void testSearch_InvalidNestedPath_ReturnsBadRequest() throws IOException {
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        BoolQueryBuilder boolQuery = new BoolQueryBuilder().must(new MatchQueryBuilder("tree.branch", "leaf"));
+        NestedQueryBuilder nestedQuery = new NestedQueryBuilder("NULL", boolQuery, ScoreMode.None);
+        searchSourceBuilder.query(nestedQuery);
+        SearchDataObjectRequest searchRequest = SearchDataObjectRequest.builder()
+            .indices(TEST_INDEX)
+            .tenantId(TEST_TENANT_ID)
+            .searchSourceBuilder(searchSourceBuilder)
+            .build();
+
+        QueryShardContext mockContext = mock(QueryShardContext.class);
+        Index mockIndex = new Index(TEST_INDEX, "_na_");
+        when(mockContext.getFullyQualifiedIndex()).thenReturn(mockIndex);
+        QueryShardException queryShardException = new QueryShardException(
+            mockContext,
+            "[nested] failed to find nested object under path [NULL]"
+        );
+        assertEquals(RestStatus.BAD_REQUEST, ExceptionsHelper.status(queryShardException));
+
+        ShardSearchFailure[] shardFailures = new ShardSearchFailure[] { new ShardSearchFailure(queryShardException) };
+        SearchPhaseExecutionException searchException = new SearchPhaseExecutionException("search", "all shards failed", shardFailures);
+        assertEquals(RestStatus.BAD_REQUEST, ExceptionsHelper.status(searchException));
+
+        OpenSearchException openSearchException = new OpenSearchException(
+            new ErrorResponse.Builder().status(ExceptionsHelper.status(searchException).getStatus())
+                .error(
+                    new ErrorCause.Builder().rootCause(
+                        List.of(
+                            new ErrorCause.Builder().type(QueryShardException.class.getSimpleName())
+                                .reason("failed to create query: [nested] failed to find nested object under path [NULL]")
+                                .metadata(Map.of("index", JsonData.of(TEST_INDEX), "index_uuid", JsonData.of("_na_")))
+                                .build()
+                        )
+                    ).type(SearchPhaseExecutionException.class.getSimpleName()).reason("all shards failed").build()
+                )
+                .build()
+        );
+        assertEquals(RestStatus.BAD_REQUEST, RestStatus.fromCode(openSearchException.status()));
+
+        when(mockedOpenSearchAsyncClient.search(any(SearchRequest.class), any())).thenReturn(
+            CompletableFuture.failedFuture(openSearchException)
+        );
+
+        CompletionStage<SearchDataObjectResponse> result = sdkClient.searchDataObjectAsync(
+            searchRequest,
+            testThreadPool.executor(TEST_THREAD_POOL)
+        );
+        ExecutionException executionException = assertThrows(ExecutionException.class, () -> result.toCompletableFuture().get());
+
+        Throwable actualCause = executionException.getCause();
+        assertTrue(actualCause instanceof OpenSearchStatusException);
+        assertEquals(RestStatus.BAD_REQUEST, ((OpenSearchStatusException) actualCause).status());
+        assertEquals("Failed to search indices [test_index]", actualCause.getMessage());
+        Throwable nestedCause = actualCause.getCause();
+        assertEquals(OpenSearchException.class, nestedCause.getClass());
+        assertTrue(nestedCause.getMessage().contains(searchException.getMessage()));
+        assertEquals(RestStatus.BAD_REQUEST.getStatus(), ((OpenSearchException) nestedCause).status());
     }
 }


### PR DESCRIPTION
### Description

The Remote client search handler:
 - wasn't properly unwrapping the CompletionException
 - was assuming that `status()` on an `OpenSearchException` was the same as an `OpenSearchStatusException`, but it's not (one is an int, one is a `RestStatus`).

Making these fixes allows it to do as intended, using the status code from a remote query.

Also during attempts to build a test class, identified the need for `QueryBuilder` subclasses to add to the default NamedXContent parser.

### Issues Resolved

Final part of #154 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
