### PR TITLE
[Backport 2.19] Make generated responses robust to URL encoded id and index values (#156)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,21 +3,13 @@ All notable changes to this project are documented in this file.
 
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
+## [Unreleased 2.19.x](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/compare/2.19...HEAD)
 ### Features
 ### Enhancements
 ### Bug Fixes
-- Improve exception unwrapping flexibility for SdkClientUtils ([#67](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/67))
-- Add util methods to handle ActionListeners in whenComplete ([#75](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/75))
-- Refactor SDKClientUtil for better readability, fix javadocs ([#78](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/78))
-- Make DynamoDBClient fully async ([#79](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/79))
-- Fix version conflict check for update ([#114](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/114))
-- Use SdkClientDelegate's classloader for ServiceLoader ([#121](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/121))
-- Ensure consistent reads on DynamoDB getItem calls ([#128](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/128))
-- Return 404 for Index not found on Local Cluster search ([#130](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/130))
+- Make generated responses robust to URL encoded id and index values ([#156](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/156))
 
 ### Infrastructure
 ### Documentation
 ### Maintenance
-- Bump aws sdk to 2.30.18 from 2.29.50 ([#93](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/93))
-
 ### Refactoring

--- a/ddb-client/src/test/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClientTests.java
+++ b/ddb-client/src/test/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClientTests.java
@@ -76,6 +76,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.opensearch.remote.metadata.client.impl.DDBOpenSearchClient.simulateOpenSearchResponse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -836,5 +837,68 @@ public class DDBOpenSearchClientTests {
             Map.entry("testList", AttributeValue.builder().l(Arrays.asList(AttributeValue.builder().s("testString").build())).build()),
             Map.entry("testObject", AttributeValue.builder().m(Map.of("data", AttributeValue.builder().s("foo").build())).build())
         );
+    }
+
+    @Test
+    public void testDeleteResponseWithQuotes() throws IOException {
+        // Test with double quote in ID
+        String json = simulateOpenSearchResponse("test-index", "\"", null, 0L, Map.of("result", "deleted"));
+
+        XContentParser parser = DDBOpenSearchClient.createParser(json);
+        DeleteResponse response = DeleteResponse.fromXContent(parser);
+
+        assertEquals("\"", response.getId());
+        assertEquals("test-index", response.getIndex());
+        assertEquals("deleted", response.getResult().toString().toLowerCase());
+    }
+
+    @Test
+    public void testGetResponseWithBackslash() throws IOException {
+        // Test with backslash in ID
+        String source = "{\"field\":\"value\"}";
+        String json = simulateOpenSearchResponse("test-index", "\\", source, 0L, Map.of("found", true));
+
+        XContentParser parser = DDBOpenSearchClient.createParser(json);
+        GetResponse response = GetResponse.fromXContent(parser);
+
+        assertEquals("\\", response.getId());
+        assertEquals("test-index", response.getIndex());
+        assertTrue(response.isExists());
+        assertNotNull(response.getSourceAsString());
+        assertEquals("{\"field\":\"value\"}", response.getSourceAsString());
+    }
+
+    @Test
+    public void testUpdateResponseWithSpecialChars() throws IOException {
+        // Test with multiple special characters in ID
+        String source = "{\"updated_field\":\"new_value\"}";
+        String json = simulateOpenSearchResponse("test-index", "<>?:\"{}|+", source, 0L, Map.of("result", "updated"));
+
+        XContentParser parser = DDBOpenSearchClient.createParser(json);
+        UpdateResponse response = UpdateResponse.fromXContent(parser);
+
+        assertEquals("<>?:\"{}|+", response.getId());
+        assertEquals("test-index", response.getIndex());
+        assertEquals("updated", response.getResult().toString().toLowerCase());
+    }
+
+    @Test
+    public void testIndexResponseWithUrlEncodedChars() throws IOException {
+        // Test with URL-encoded characters in both index and ID
+        String source = "{\"new_field\":\"test_value\"}";
+        String json = simulateOpenSearchResponse(
+            "test%20index",
+            "%22%3C%3E", // URL encoded "<>"
+            source,
+            0L,
+            Map.of("result", "created")
+        );
+
+        XContentParser parser = DDBOpenSearchClient.createParser(json);
+        IndexResponse response = IndexResponse.fromXContent(parser);
+
+        assertEquals("%22%3C%3E", response.getId());
+        assertEquals("test%20index", response.getIndex());
+        assertEquals("created", response.getResult().toString().toLowerCase());
     }
 }


### PR DESCRIPTION
Backport 3d24da321a036bc0a1094145244901cd2e555d61 from #156 