### PR TITLE
[Backport 2.19] Validate request fields in DDB Put and Update implementations (#157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Enhancements
 ### Bug Fixes
 - Make generated responses robust to URL encoded id and index values ([#156](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/156))
+- Validate request fields in DDB Put and Update implementations ([#157](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/157))
 
 ### Infrastructure
 ### Documentation


### PR DESCRIPTION
Backport f7ab90c113676899ce9d787113dcd277a0c99731 from #157 
