### PR TITLE
[Backport 2.19] Properly handle remote client search failures with status codes (#158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Bug Fixes
 - Make generated responses robust to URL encoded id and index values ([#156](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/156))
 - Validate request fields in DDB Put and Update implementations ([#157](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/157))
+- Properly handle remote client search failures with status codes ([#158](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/158))
 
 ### Infrastructure
 ### Documentation

--- a/remote-client/src/main/java/org/opensearch/remote/metadata/client/impl/RemoteClusterIndicesClient.java
+++ b/remote-client/src/main/java/org/opensearch/remote/metadata/client/impl/RemoteClusterIndicesClient.java
@@ -451,6 +451,13 @@ public class RemoteClusterIndicesClient extends AbstractSdkClient {
                 SearchResponse<?> searchResponse = openSearchClient.search(searchRequest, MAP_DOCTYPE);
                 log.info("Search returned {} hits", searchResponse.hits().total().value());
                 return SearchDataObjectResponse.builder().parser(createParser(searchResponse)).build();
+            } catch (OpenSearchException e) {
+                log.error("Error searching {}: {}", Arrays.toString(request.indices()), e.getMessage(), e);
+                throw new OpenSearchStatusException(
+                    "Failed to search indices " + Arrays.toString(request.indices()),
+                    RestStatus.fromCode(e.status()),
+                    e
+                );
             } catch (IOException e) {
                 log.error("Error searching {}: {}", Arrays.toString(request.indices()), e.getMessage(), e);
                 // Rethrow unchecked exception on exception


### PR DESCRIPTION
Backports c7ae10438c0f2acb3d08142e9a34a6a8d965f23a from #158 