### PR TITLE
Get AWSSDK BOM version from version catalog

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -39,14 +39,7 @@
     "addLabels": ["skip-changelog"],
     "workflowRules": {
       "enabled": true
-    },
-    "packageRules": [
-      {
-        "matchPackageNames": ["software.amazon.awssdk:bom"],
-        "automerge": false,
-        "enabled": false
-      }
-    ]
+    }
   },
    "imageSettings":{
        "imageTracing":{

--- a/aos-client/build.gradle
+++ b/aos-client/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
     implementation "org.opensearch.client:opensearch-java:${opensearch_java_version}"
 
-    implementation(platform("software.amazon.awssdk:bom:${aws_sdk_version}"))
+    implementation(platform("software.amazon.awssdk:bom:${versions.aws}"))
     implementation("software.amazon.awssdk:apache-client")
     implementation("software.amazon.awssdk:sdk-core")
     implementation("software.amazon.awssdk:aws-core")

--- a/ddb-client/build.gradle
+++ b/ddb-client/build.gradle
@@ -9,6 +9,6 @@ dependencies {
     implementation project(':opensearch-remote-metadata-sdk-remote-client')
     implementation project(':opensearch-remote-metadata-sdk-aos-client')
 
-    implementation(platform("software.amazon.awssdk:bom:${aws_sdk_version}"))
+    implementation(platform("software.amazon.awssdk:bom:${versions.aws}"))
     implementation "software.amazon.awssdk:dynamodb"
 }


### PR DESCRIPTION
### Description

Gets the `aws` version from the version catalog to reduce version conflicts.

Also removes the exclusion from version bumps that I put in after getting daily version bumps.

Initially did this to see if it resolved dependency issues from plugins, but the problems all stem from `opensearch-java` which is needed at runtime for the remote SDK implementations but conflicts with OpenSearch 3.x test dependencies.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
