### PR TITLE
Remove unneeded enum uppercase workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Documentation
 ### Maintenance
 ### Refactoring
+- Remove unneeded enum uppercase workaround ([#185](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/185))

--- a/core/src/main/java/org/opensearch/remote/metadata/common/SdkClientUtils.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/common/SdkClientUtils.java
@@ -454,7 +454,9 @@ public class SdkClientUtils {
      * @param field The JSON field to lowercase the value
      * @param json The full JSON to process
      * @return The JSON with the value lowercased
+     * @deprecated No longer required with OpenSearch Java Client v3
      */
+    @Deprecated
     public static String lowerCaseEnumValues(String field, String json) {
         if (field == null) {
             return json;

--- a/core/src/test/java/org/opensearch/remote/metadata/common/SdkClientUtilsTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/common/SdkClientUtilsTests.java
@@ -80,6 +80,7 @@ public class SdkClientUtilsTests {
         testDataObject = new TestDataObject("foo");
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void testLowerCaseEnumValues() {
         // Test normal case

--- a/remote-client/src/main/java/org/opensearch/remote/metadata/client/impl/RemoteClusterIndicesClient.java
+++ b/remote-client/src/main/java/org/opensearch/remote/metadata/client/impl/RemoteClusterIndicesClient.java
@@ -59,7 +59,6 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
-import org.opensearch.index.query.MatchPhraseQueryBuilder;
 import org.opensearch.remote.metadata.client.AbstractSdkClient;
 import org.opensearch.remote.metadata.client.BulkDataObjectRequest;
 import org.opensearch.remote.metadata.client.BulkDataObjectResponse;
@@ -502,12 +501,7 @@ public class RemoteClusterIndicesClient extends AbstractSdkClient {
         return doPrivileged(() -> {
             try {
                 log.info("Searching {}", Arrays.toString(request.indices()));
-                // work around https://github.com/opensearch-project/opensearch-java/issues/1150
-                String json = SdkClientUtils.lowerCaseEnumValues(
-                    MatchPhraseQueryBuilder.ZERO_TERMS_QUERY_FIELD.getPreferredName(),
-                    request.searchSourceBuilder().toString()
-                );
-                JsonParser parser = mapper.jsonProvider().createParser(new StringReader(json));
+                JsonParser parser = mapper.jsonProvider().createParser(new StringReader(request.searchSourceBuilder().toString()));
                 SearchRequest searchRequest = SearchRequest._DESERIALIZER.deserialize(parser, mapper);
                 if (Boolean.TRUE.equals(isMultiTenancyEnabled)) {
                     if (request.tenantId() == null) {


### PR DESCRIPTION
### Description

Removes the enum casing workaround for https://github.com/opensearch-project/opensearch-java/issues/1150 as the issue has been fixed in v3, merged in https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/182.

### Issues Resolved

Fixes #184

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
