### PR TITLE
Generate random ID for empty ID string on DDB Client - 2.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Features
 ### Enhancements
 ### Bug Fixes
+- Generate random ID for empty ID string on DDB Client ([#191])
 - Make generated responses robust to URL encoded id and index values ([#156](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/156))
 - Validate request fields in DDB Put and Update implementations ([#157](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/157))
 - Properly handle remote client search failures with status codes ([#158](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/158))

--- a/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClient.java
+++ b/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClient.java
@@ -166,7 +166,7 @@ public class DDBOpenSearchClient extends AbstractSdkClient {
         Executor executor,
         Boolean isMultiTenancyEnabled
     ) {
-        final String id = request.id() != null ? request.id() : UUID.randomUUID().toString();
+        final String id = Strings.isNullOrEmpty(request.id()) ? UUID.randomUUID().toString() : request.id();
         // Validate parameters and data object body
         try (XContentBuilder sourceBuilder = XContentFactory.jsonBuilder()) {
             IndexRequest indexRequest = new IndexRequest(request.index()).opType(request.overwriteIfExists() ? OpType.INDEX : OpType.CREATE)

--- a/ddb-client/src/test/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClientTests.java
+++ b/ddb-client/src/test/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClientTests.java
@@ -285,6 +285,28 @@ public class DDBOpenSearchClientTests {
         PutItemRequest putItemRequest = putItemRequestArgumentCaptor.getValue();
         assertNotNull(putItemRequest.item().get(RANGE_KEY).s());
         assertNotNull(response.id());
+        assertFalse(response.id().isEmpty());
+    }
+
+    @Test
+    public void testPutDataObject_EmptyId_GeneratesId() {
+        PutDataObjectRequest putRequest = PutDataObjectRequest.builder()
+            .index(TEST_INDEX)
+            .id("")
+            .tenantId(TENANT_ID)
+            .dataObject(testDataObject)
+            .build();
+        when(dynamoDbAsyncClient.putItem(any(PutItemRequest.class))).thenReturn(
+            CompletableFuture.completedFuture(PutItemResponse.builder().build())
+        );
+        PutDataObjectResponse response = sdkClient.putDataObjectAsync(putRequest, testThreadPool.executor(TEST_THREAD_POOL))
+            .toCompletableFuture()
+            .join();
+        verify(dynamoDbAsyncClient).putItem(putItemRequestArgumentCaptor.capture());
+
+        PutItemRequest putItemRequest = putItemRequestArgumentCaptor.getValue();
+        assertNotNull(putItemRequest.item().get(RANGE_KEY).s());
+        assertFalse(response.id().isEmpty());
     }
 
     @Test


### PR DESCRIPTION
### Description
This is to port the fix in https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/192

Generates a random document (item) id when an empty string is provided on DDB Client for the `PutDataRequestObject`

```
DDBOpenSearchClientTests > testPutDataObject_EmptyId_GeneratesId() FAILED
    org.opentest4j.AssertionFailedError: expected: <false> but was: <true>
        at app//org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
        at app//org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
        at app//org.junit.jupiter.api.AssertFalse.failNotFalse(AssertFalse.java:63)
        at app//org.junit.jupiter.api.AssertFalse.assertFalse(AssertFalse.java:36)
        at app//org.junit.jupiter.api.AssertFalse.assertFalse(AssertFalse.java:31)
        at app//org.junit.jupiter.api.Assertions.assertFalse(Assertions.java:231)
        at app//org.opensearch.remote.metadata.client.impl.DDBOpenSearchClientTests.testPutDataObject_EmptyId_GeneratesId(DDBOpenSearchClientTests.java:309)
```

### Issues Resolved
- Fixes https://github.com/opensearch-project/opensearch-remote-metadata-sdk/issues/191

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
