### PR TITLE
Put httpclient5 version resolution in allprojects block

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,18 +40,6 @@ buildscript {
     }
 }
 
-// Fix for CVE-2025-27820
-configurations.all {
-    resolutionStrategy {
-        eachDependency { DependencyResolveDetails details ->
-            if (details.requested.group == 'org.apache.httpcomponents.client5' &&
-                    details.requested.name == 'httpclient5') {
-                details.useVersion "${versions.httpclient5}"
-            }
-        }
-    }
-}
-
 allprojects {
     apply plugin: 'java'
     apply plugin: 'idea'
@@ -89,6 +77,17 @@ allprojects {
         toolVersion = "latest.release"
     }
 
+    // Fix for CVE-2025-27820
+    configurations.all {
+        resolutionStrategy {
+            eachDependency { DependencyResolveDetails details ->
+                if (details.requested.group == 'org.apache.httpcomponents.client5' &&
+                        details.requested.name == 'httpclient5') {
+                    details.useVersion "${versions.httpclient5}"
+                }
+            }
+        }
+    }
 }
 
 subprojects {


### PR DESCRIPTION
### Description

Moves the httpclient5 dependency resolution into the allprojects block.  At the top level it wasn't being applied to subprojects.

### Issues Resolved

(Finally) Fixes CVE-2025-27820


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
