### PR TITLE
Exclude httpclient5 from checkstyle import to resolve CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,15 +78,9 @@ allprojects {
     }
 
     // Fix for CVE-2025-27820
-    configurations.all {
-        resolutionStrategy {
-            eachDependency { DependencyResolveDetails details ->
-                if (details.requested.group == 'org.apache.httpcomponents.client5' &&
-                        details.requested.name == 'httpclient5') {
-                    details.useVersion "${versions.httpclient5}"
-                }
-            }
-        }
+    configurations.checkstyle {
+        exclude group: 'org.apache.httpcomponents.client5', module: 'httpclient5'
+        exclude group: 'org.apache.httpcomponents.core5', module: 'httpcore5'
     }
 }
 


### PR DESCRIPTION
### Description

Rather than forcing the version, just excluding the conflicting dependencies from the checkstyle transient import.

### Issues Resolved

(Really, this time) Fixes https://github.com/advisories/GHSA-73m2-qfq3-56cx

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
