### PR TITLE
Add global resource support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ import org.opensearch.gradle.VersionProperties
 buildscript {
     ext {
         opensearch_group = "org.opensearch"
-        opensearch_version = System.getProperty("opensearch.version", "3.2.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "3.1.0-SNAPSHOT")
         is_snapshot = "true" == System.getProperty("build.snapshot", "true")
         build_version_qualifier = System.getProperty("build.version_qualifier", "")
 

--- a/core/src/main/java/org/opensearch/remote/metadata/client/SdkClient.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/SdkClient.java
@@ -268,6 +268,16 @@ public class SdkClient {
     }
 
     /**
+     * This method is to
+     * @param index
+     * @param id
+     * @return
+     */
+    public boolean isGlobalResource(String index, String id) {
+        return delegate.isGlobalResource(index, id);
+    }
+
+    /**
      * Throw exception if tenantId is null and multitenancy is enabled
      * @param tenantId The tenantId from the request
      */

--- a/core/src/main/java/org/opensearch/remote/metadata/client/SdkClientDelegate.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/SdkClientDelegate.java
@@ -114,4 +114,17 @@ public interface SdkClientDelegate extends AutoCloseable {
         Executor executor,
         Boolean isMultiTenancyEnabled
     );
+
+    /**
+     * This method is to check if a given resource index and id is global resource or not.
+     * This is useful for invokers in case they need perform different operations based on
+     * resource type. It's false by default since for most cases, override this method if
+     * otherwise.
+     * @param index The index/table name.
+     * @param id The resource id.
+     * @return If the resource is global or not.
+     */
+    default boolean isGlobalResource(String index, String id) {
+        return false;
+    }
 }

--- a/core/src/main/java/org/opensearch/remote/metadata/common/CommonValue.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/common/CommonValue.java
@@ -26,6 +26,8 @@ public class CommonValue {
     public static final String REMOTE_METADATA_REGION_KEY = "remote_metadata_region";
     /** The key for remote metadata service name used by service-specific SDKs */
     public static final String REMOTE_METADATA_SERVICE_NAME_KEY = "remote_metadata_service_name";
+    /** A configurable tenant id to identify global resources. */
+    public static final String REMOTE_METADATA_GLOBAL_TENANT_ID_KEY = "global_tenant_id";
 
     /** The value for remote metadata type for a remote OpenSearch cluster compatible with OpenSearch Java Client. */
     public static final String REMOTE_OPENSEARCH = "RemoteOpenSearch";


### PR DESCRIPTION
### Description
## Overview
This PR introduces comprehensive global resource support to the OpenSearch Remote Metadata SDK, enabling shared resources across multiple tenants in multi-tenancy environments.

## Changes

### Core Interface Enhancements
- **New Method**: Added `isGlobalResource(String index, String id)` to `SdkClient` and `SdkClientDelegate` interfaces
- **Configuration**: Added `REMOTE_METADATA_GLOBAL_TENANT_ID_KEY` constant for global tenant identification

### DynamoDB Client Implementation
- **Global Resource Caching**: Implemented automatic scanning and caching of global resources during client initialization
- **Cache-First Retrieval**: Enhanced `getDataObjectAsync()` to prioritize cached global resources
- **Dynamic Tenant ID Replacement**: Global resources dynamically adapt tenant ID in responses for seamless access
- **Security Enhancement**: Added validation to prevent direct operations on reserved global tenant ID (`_global_tenant_id`)

### Performance Optimizations
- **Concurrent Table Scanning**: Parallel DynamoDB table description and global resource fetching
- **In-Memory Cache**: `ConcurrentHashMap`-based caching for fast global resource access
- **Reduced Query Load**: Eliminates repeated queries for frequently accessed global resources

## Security Considerations
- Global tenant ID is reserved for internal use only
- PUT/UPDATE/DELETE operations reject requests with global tenant ID
- Global resources are read-only from tenant perspective


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
