### PR TITLE
[Backport 2.19] Avoid race condition putting the same document id in DDB Client (#228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Features
 ### Enhancements
 ### Bug Fixes
-- Make generated responses robust to URL encoded id and index values ([#156](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/156))
-- Validate request fields in DDB Put and Update implementations ([#157](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/157))
-- Properly handle remote client search failures with status codes ([#158](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/158))
+- Avoid race condition putting the same document id in DDB Client ([#228](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/228))
 
 ### Infrastructure
 ### Documentation

--- a/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClient.java
+++ b/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClient.java
@@ -185,6 +185,14 @@ public class DDBOpenSearchClient extends AbstractSdkClient {
 
         return doPrivileged(() -> dynamoDbAsyncClient.getItem(getItemRequest).thenCompose(getItemResponse -> {
             try {
+                // Fail fast if item exists to save an attempted conditional write
+                if (!request.overwriteIfExists()
+                    && getItemResponse != null
+                    && getItemResponse.item() != null
+                    && !getItemResponse.item().isEmpty()) {
+                    throw new OpenSearchStatusException("Existing data object for ID: " + request.id(), RestStatus.CONFLICT);
+                }
+
                 Long sequenceNumber = initOrIncrementSeqNo(getItemResponse);
                 String source = Strings.toString(MediaTypeRegistry.JSON, request.dataObject());
                 JsonNode jsonNode = OBJECT_MAPPER.readTree(source);
@@ -199,11 +207,10 @@ public class DDBOpenSearchClient extends AbstractSdkClient {
                 item.put(SEQ_NO_KEY, AttributeValue.builder().n(sequenceNumber.toString()).build());
                 PutItemRequest.Builder builder = PutItemRequest.builder().tableName(tableName).item(item);
 
-                if (!request.overwriteIfExists()
-                    && getItemResponse != null
-                    && getItemResponse.item() != null
-                    && !getItemResponse.item().isEmpty()) {
-                    throw new OpenSearchStatusException("Existing data object for ID: " + request.id(), RestStatus.CONFLICT);
+                // Protect against race condition if another thread just created this
+                if (!request.overwriteIfExists()) {
+                    builder.conditionExpression("attribute_not_exists(#hk) AND attribute_not_exists(#rk)")
+                        .expressionAttributeNames(Map.of("#hk", HASH_KEY, "#rk", RANGE_KEY));
                 }
 
                 final PutItemRequest putItemRequest = builder.build();
@@ -221,7 +228,17 @@ public class DDBOpenSearchClient extends AbstractSdkClient {
                     } catch (IOException e) {
                         throw new OpenSearchStatusException("Failed to create parser for response", RestStatus.INTERNAL_SERVER_ERROR, e);
                     }
-                });
+                })
+                    // Thrown if overwriteIfExists is false
+                    .exceptionally(e -> {
+                        if (e.getCause() instanceof ConditionalCheckFailedException) {
+                            throw new OpenSearchStatusException("Concurrent write detected for ID: " + request.id(), RestStatus.CONFLICT);
+                        }
+                        if (e instanceof RuntimeException) {
+                            throw (RuntimeException) e;
+                        }
+                        throw new CompletionException(e);
+                    });
             } catch (IOException e) {
                 throw new OpenSearchStatusException("Failed to parse data object " + request.id(), RestStatus.BAD_REQUEST, e);
             }

--- a/ddb-client/src/test/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClientTests.java
+++ b/ddb-client/src/test/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClientTests.java
@@ -237,6 +237,47 @@ public class DDBOpenSearchClientTests {
     }
 
     @Test
+    public void testPutDataObject_ConcurrentWrite_ThrowsConflict() {
+        PutDataObjectRequest putRequest = PutDataObjectRequest.builder()
+            .index(TEST_INDEX)
+            .id(TEST_ID)
+            .tenantId(TENANT_ID)
+            .overwriteIfExists(false)
+            .dataObject(testDataObject)
+            .build();
+
+        // Mock the getItem to return no existing item
+        when(dynamoDbAsyncClient.getItem(any(GetItemRequest.class))).thenReturn(
+            CompletableFuture.completedFuture(GetItemResponse.builder().build())
+        );
+
+        // Mock putItem to throw ConditionalCheckFailedException
+        ConditionalCheckFailedException conditionalCheckFailedException = ConditionalCheckFailedException.builder()
+            .message("The conditional request failed")
+            .build();
+        when(dynamoDbAsyncClient.putItem(any(PutItemRequest.class))).thenReturn(
+            CompletableFuture.failedFuture(conditionalCheckFailedException)
+        );
+
+        CompletableFuture<PutDataObjectResponse> future = sdkClient.putDataObjectAsync(
+            putRequest,
+            testThreadPool.executor(TEST_THREAD_POOL)
+        ).toCompletableFuture();
+
+        CompletionException ce = assertThrows(CompletionException.class, () -> future.join());
+        assertTrue(ce.getCause() instanceof OpenSearchStatusException);
+        OpenSearchStatusException ose = (OpenSearchStatusException) ce.getCause();
+        assertEquals(RestStatus.CONFLICT, ose.status());
+        assertEquals("Concurrent write detected for ID: " + TEST_ID, ose.getMessage());
+
+        // Verify that the conditional expression was set correctly
+        verify(dynamoDbAsyncClient).putItem(putItemRequestArgumentCaptor.capture());
+        PutItemRequest capturedRequest = putItemRequestArgumentCaptor.getValue();
+        assertEquals("attribute_not_exists(#hk) AND attribute_not_exists(#rk)", capturedRequest.conditionExpression());
+        assertEquals(Map.of("#hk", HASH_KEY, "#rk", RANGE_KEY), capturedRequest.expressionAttributeNames());
+    }
+
+    @Test
     public void testPutDataObject_WithComplexData() {
         ComplexDataObject complexDataObject = ComplexDataObject.builder()
             .testString("testString")


### PR DESCRIPTION
Backport 8f7ce22ae4750507cb6a2757dd1b55bbe402bf76 from #228
