### PR TITLE
Throw exception on empty string for put request ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@ All notable changes to this project are documented in this file.
 
 Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
-## [Unreleased 3.2](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/compare/3.1...HEAD)
+## [Unreleased 3.3](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/compare/3.2...HEAD)
 ### Features
 ### Enhancements
 ### Bug Fixes
-- Avoid race condition putting the same document id in DDB Client ([#228](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/228))
+- Throw exception on empty string for put request ID ([#235](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/235))
 
 ### Infrastructure
 ### Documentation

--- a/core/src/main/java/org/opensearch/remote/metadata/client/AbstractSdkClient.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/AbstractSdkClient.java
@@ -53,4 +53,17 @@ public abstract class AbstractSdkClient implements SdkClientDelegate {
     protected <T> CompletionStage<T> executePrivilegedAsync(PrivilegedAction<T> action, Executor executor) {
         return CompletableFuture.supplyAsync(() -> doPrivileged(action), executor);
     }
+
+    /**
+     * Determine if we should use the user-provided document id
+     * @param id the document id
+     * @return true if the id is not null
+     * @throws IllegalArgumentException if the id is an empty string
+     */
+    protected boolean shouldUseId(String id) {
+        if ("".equals(id)) {
+            throw new IllegalArgumentException("if _id is specified it must not be empty");
+        }
+        return id != null;
+    }
 }

--- a/core/src/main/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClient.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClient.java
@@ -126,7 +126,7 @@ public class LocalClusterIndicesClient extends AbstractSdkClient {
             IndexRequest indexRequest = new IndexRequest(putDataObjectRequest.index()).opType(
                 putDataObjectRequest.overwriteIfExists() ? OpType.INDEX : OpType.CREATE
             ).source(putDataObjectRequest.dataObject().toXContent(sourceBuilder, EMPTY_PARAMS));
-            if (!Strings.isNullOrEmpty(putDataObjectRequest.id())) {
+            if (shouldUseId(putDataObjectRequest.id())) {
                 indexRequest.id(putDataObjectRequest.id());
             }
             return indexRequest;

--- a/core/src/test/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClientTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClientTests.java
@@ -77,6 +77,7 @@ import org.mockito.MockitoAnnotations;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.opensearch.remote.metadata.common.CommonValue.TENANT_ID_FIELD_KEY;
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -147,6 +148,37 @@ public class LocalClusterIndicesClientTests {
         IndexResponse indexActionResponse = IndexResponse.fromXContent(response.parser());
         assertEquals(TEST_ID, indexActionResponse.getId());
         assertEquals(DocWriteResponse.Result.CREATED, indexActionResponse.getResult());
+
+        // Test null id
+        putRequest = PutDataObjectRequest.builder()
+            .index(TEST_INDEX)
+            .tenantId(TEST_TENANT_ID)
+            .overwriteIfExists(false)
+            .dataObject(testDataObject)
+            .build();
+
+        response = sdkClient.putDataObjectAsync(putRequest).toCompletableFuture().join();
+
+        requestCaptor = ArgumentCaptor.forClass(IndexRequest.class);
+        verify(mockedClient, times(2)).index(requestCaptor.capture(), any());
+        assertEquals(TEST_INDEX, requestCaptor.getValue().index());
+        assertNull(TEST_ID, requestCaptor.getValue().id());
+        assertEquals(OpType.CREATE, requestCaptor.getValue().opType());
+
+        // Test empty id
+        final PutDataObjectRequest putRequestEmptyId = PutDataObjectRequest.builder()
+            .index(TEST_INDEX)
+            .id("")
+            .tenantId(TEST_TENANT_ID)
+            .overwriteIfExists(false)
+            .dataObject(testDataObject)
+            .build();
+
+        IllegalArgumentException ex = assertThrows(
+            IllegalArgumentException.class,
+            () -> sdkClient.putDataObjectAsync(putRequestEmptyId).toCompletableFuture().join()
+        );
+        assertEquals("if _id is specified it must not be empty", ex.getMessage());
     }
 
     @Test

--- a/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClient.java
+++ b/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClient.java
@@ -164,7 +164,7 @@ public class DDBOpenSearchClient extends AbstractSdkClient {
         Executor executor,
         Boolean isMultiTenancyEnabled
     ) {
-        final String id = request.id() != null ? request.id() : UUID.randomUUID().toString();
+        final String id = shouldUseId(request.id()) ? request.id() : UUID.randomUUID().toString();
         // Validate parameters and data object body
         try (XContentBuilder sourceBuilder = XContentFactory.jsonBuilder()) {
             IndexRequest indexRequest = new IndexRequest(request.index()).opType(request.overwriteIfExists() ? OpType.INDEX : OpType.CREATE)

--- a/remote-client/src/main/java/org/opensearch/remote/metadata/client/impl/RemoteClusterIndicesClient.java
+++ b/remote-client/src/main/java/org/opensearch/remote/metadata/client/impl/RemoteClusterIndicesClient.java
@@ -152,7 +152,7 @@ public class RemoteClusterIndicesClient extends AbstractSdkClient {
                     .opType(request.overwriteIfExists() ? OpType.Index : OpType.Create)
                     .document(request.dataObject())
                     .tDocumentSerializer(new JsonTransformer.XContentObjectJsonpSerializer());
-                if (!Strings.isNullOrEmpty(request.id())) {
+                if (shouldUseId(request.id())) {
                     builder.id(request.id());
                 }
                 IndexRequest<?> indexRequest = builder.build();


### PR DESCRIPTION
### Description

Aligns metadata client implementation behavior with OpenSearch: 
https://github.com/opensearch-project/OpenSearch/blob/f967a72279a54032ba9ef3df4a33f8a7f850d66d/server/src/main/java/org/opensearch/action/index/IndexRequest.java#L629-L649

Null id generates random id (current behavior)
Empty string throws 400 exception (matches current behavior on Local/remote client, although catches it earlier; changes DDB behavior which currently allows an empty string id)

### Issues Resolved

Fixes #191 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
