### PR TITLE
Add RefreshPolicy and timeout support to Put, Update, Delete, and Bulk requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ### Enhancements
 - Add SeqNo and PrimaryTerm support to Put and Delete requests ([#234](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/234))
+- Add RefreshPolicy and timeout support to Put, Update, Delete, and Bulk requests ([#244](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/244))
 
 ### Bug Fixes
 - Throw exception on empty string for put request ID ([#235](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/235))

--- a/core/src/main/java/org/opensearch/remote/metadata/client/BulkDataObjectRequest.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/BulkDataObjectRequest.java
@@ -71,10 +71,11 @@ public class BulkDataObjectRequest {
 
     /**
      * Add the given request to the {@link BulkDataObjectRequest}
+     * @param <R> The specific type of WriteDataObjectRequest
      * @param request The request to add
      * @return the updated request object
      */
-    public BulkDataObjectRequest add(WriteDataObjectRequest request) {
+    public <R extends WriteDataObjectRequest<R>> BulkDataObjectRequest add(R request) {
         if (Strings.isNullOrEmpty(request.index())) {
             if (Strings.isNullOrEmpty(globalIndex)) {
                 throw new IllegalArgumentException(

--- a/core/src/main/java/org/opensearch/remote/metadata/client/BulkDataObjectRequest.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/BulkDataObjectRequest.java
@@ -25,7 +25,7 @@ public class BulkDataObjectRequest {
 
     private final List<DataObjectRequest> requests = new ArrayList<>();
     private final Set<String> indices = new HashSet<>();
-    private RefreshPolicy refreshPolicy = RefreshPolicy.NONE;
+    private RefreshPolicy refreshPolicy = RefreshPolicy.IMMEDIATE;
     private String globalIndex;
 
     /**
@@ -86,6 +86,8 @@ public class BulkDataObjectRequest {
         } else {
             indices.add(request.index());
         }
+        // Bulk Requests require this on individual requests
+        request.setRefreshPolicy(RefreshPolicy.NONE);
         requests.add(request);
         return this;
     }
@@ -93,6 +95,7 @@ public class BulkDataObjectRequest {
     /**
      * Should this request trigger a refresh ({@linkplain RefreshPolicy#IMMEDIATE}), wait for a refresh (
      * {@linkplain RefreshPolicy#WAIT_UNTIL}), or proceed ignore refreshes entirely ({@linkplain RefreshPolicy#NONE}, the default).
+     * Note this applies to the combined Bulk Request itself, the individual requests all use {@linkplain RefreshPolicy#NONE}.
      * @param refreshPolicy the refresh policy
      * @return the updated request
      */
@@ -104,6 +107,7 @@ public class BulkDataObjectRequest {
     /**
      * Should this request trigger a refresh ({@linkplain RefreshPolicy#IMMEDIATE}), wait for a refresh (
      * {@linkplain RefreshPolicy#WAIT_UNTIL}), or proceed ignore refreshes entirely ({@linkplain RefreshPolicy#NONE}, the default).
+     * Note this applies to the combined Bulk Request itself, the individual requests all use {@linkplain RefreshPolicy#NONE}.
      * @return the refresh policy
      */
     public RefreshPolicy getRefreshPolicy() {

--- a/core/src/main/java/org/opensearch/remote/metadata/client/BulkDataObjectRequest.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/BulkDataObjectRequest.java
@@ -10,6 +10,7 @@ package org.opensearch.remote.metadata.client;
 
 import org.opensearch.action.support.WriteRequest.RefreshPolicy;
 import org.opensearch.common.Nullable;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.common.Strings;
 
 import java.util.ArrayList;
@@ -26,6 +27,7 @@ public class BulkDataObjectRequest {
     private final List<DataObjectRequest> requests = new ArrayList<>();
     private final Set<String> indices = new HashSet<>();
     private RefreshPolicy refreshPolicy = RefreshPolicy.IMMEDIATE;
+    private TimeValue timeout = TimeValue.timeValueMinutes(1L);
     private String globalIndex;
 
     /**
@@ -97,6 +99,7 @@ public class BulkDataObjectRequest {
      * Should this request trigger a refresh ({@linkplain RefreshPolicy#IMMEDIATE}), wait for a refresh (
      * {@linkplain RefreshPolicy#WAIT_UNTIL}), or proceed ignore refreshes entirely ({@linkplain RefreshPolicy#NONE}, the default).
      * Note this applies to the combined Bulk Request itself, the individual requests all use {@linkplain RefreshPolicy#NONE}.
+     * May not be applicable on all clients. Defaults to {@code IMMEDIATE}.
      * @param refreshPolicy the refresh policy
      * @return the updated request
      */
@@ -109,10 +112,38 @@ public class BulkDataObjectRequest {
      * Should this request trigger a refresh ({@linkplain RefreshPolicy#IMMEDIATE}), wait for a refresh (
      * {@linkplain RefreshPolicy#WAIT_UNTIL}), or proceed ignore refreshes entirely ({@linkplain RefreshPolicy#NONE}, the default).
      * Note this applies to the combined Bulk Request itself, the individual requests all use {@linkplain RefreshPolicy#NONE}.
+     * May not be applicable on all clients. Defaults to {@code IMMEDIATE}.
      * @return the refresh policy
      */
     public RefreshPolicy getRefreshPolicy() {
         return refreshPolicy;
+    }
+
+    /**
+     * A timeout to wait if the index operation can't be performed immediately. May not be applicable on all clients. Defaults to {@code 1m}.
+     * @param timeout The timeout to set
+     * @return the request after updating the timeout
+     */
+    public final BulkDataObjectRequest timeout(TimeValue timeout) {
+        this.timeout = timeout;
+        return this;
+    }
+
+    /**
+     * A timeout to wait if the index operation can't be performed immediately. May not be applicable on all clients. Defaults to {@code 1m}.
+     * @param timeout The timeout to set
+     * @return the request after updating the timeout
+     */
+    public final BulkDataObjectRequest timeout(String timeout) {
+        return timeout(TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout"));
+    }
+
+    /**
+     * A timeout to wait if the index operation can't be performed immediately. May not be applicable on all clients. Defaults to {@code 1m}.
+     * @return the timeout
+     */
+    public TimeValue timeout() {
+        return timeout;
     }
 
     /**

--- a/core/src/main/java/org/opensearch/remote/metadata/client/DeleteDataObjectRequest.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/DeleteDataObjectRequest.java
@@ -13,7 +13,7 @@ import org.opensearch.action.support.WriteRequest.RefreshPolicy;
 /**
  * A class abstracting an OpenSearch DeleteRequest
  */
-public class DeleteDataObjectRequest extends WriteDataObjectRequest {
+public class DeleteDataObjectRequest extends WriteDataObjectRequest<DeleteDataObjectRequest> {
 
     /**
      * Instantiate this request with an index and id.

--- a/core/src/main/java/org/opensearch/remote/metadata/client/DeleteDataObjectRequest.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/DeleteDataObjectRequest.java
@@ -8,6 +8,8 @@
  */
 package org.opensearch.remote.metadata.client;
 
+import org.opensearch.action.support.WriteRequest.RefreshPolicy;
+
 /**
  * A class abstracting an OpenSearch DeleteRequest
  */
@@ -22,9 +24,17 @@ public class DeleteDataObjectRequest extends WriteDataObjectRequest {
      * @param tenantId the tenant id
      * @param ifSeqNo the sequence number to match or null if not required
      * @param ifPrimaryTerm the primary term to match or null if not required
+     * @param refreshPolicy when should the written data be refreshed. May not be applicable on all clients.
      */
-    public DeleteDataObjectRequest(String index, String id, String tenantId, Long ifSeqNo, Long ifPrimaryTerm) {
-        super(index, id, tenantId, ifSeqNo, ifPrimaryTerm, false);
+    public DeleteDataObjectRequest(
+        String index,
+        String id,
+        String tenantId,
+        Long ifSeqNo,
+        Long ifPrimaryTerm,
+        RefreshPolicy refreshPolicy
+    ) {
+        super(index, id, tenantId, ifSeqNo, ifPrimaryTerm, refreshPolicy, false);
     }
 
     /**
@@ -46,7 +56,7 @@ public class DeleteDataObjectRequest extends WriteDataObjectRequest {
          */
         public DeleteDataObjectRequest build() {
             WriteDataObjectRequest.validateSeqNoAndPrimaryTerm(this.ifSeqNo, this.ifPrimaryTerm, false);
-            return new DeleteDataObjectRequest(this.index, this.id, this.tenantId, this.ifSeqNo, this.ifPrimaryTerm);
+            return new DeleteDataObjectRequest(this.index, this.id, this.tenantId, this.ifSeqNo, this.ifPrimaryTerm, this.refreshPolicy);
         }
     }
 }

--- a/core/src/main/java/org/opensearch/remote/metadata/client/DeleteDataObjectRequest.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/DeleteDataObjectRequest.java
@@ -9,6 +9,7 @@
 package org.opensearch.remote.metadata.client;
 
 import org.opensearch.action.support.WriteRequest.RefreshPolicy;
+import org.opensearch.common.unit.TimeValue;
 
 /**
  * A class abstracting an OpenSearch DeleteRequest
@@ -24,7 +25,8 @@ public class DeleteDataObjectRequest extends WriteDataObjectRequest<DeleteDataOb
      * @param tenantId the tenant id
      * @param ifSeqNo the sequence number to match or null if not required
      * @param ifPrimaryTerm the primary term to match or null if not required
-     * @param refreshPolicy when should the written data be refreshed. May not be applicable on all clients.
+     * @param refreshPolicy when should the written data be refreshed. May not be applicable on all clients. Defaults to {@code IMMEDIATE}.
+     * @param timeout A timeout to wait if the index operation can't be performed immediately. May not be applicable on all clients. Defaults to {@code 1m}.
      */
     public DeleteDataObjectRequest(
         String index,
@@ -32,9 +34,10 @@ public class DeleteDataObjectRequest extends WriteDataObjectRequest<DeleteDataOb
         String tenantId,
         Long ifSeqNo,
         Long ifPrimaryTerm,
-        RefreshPolicy refreshPolicy
+        RefreshPolicy refreshPolicy,
+        TimeValue timeout
     ) {
-        super(index, id, tenantId, ifSeqNo, ifPrimaryTerm, refreshPolicy, false);
+        super(index, id, tenantId, ifSeqNo, ifPrimaryTerm, refreshPolicy, timeout, false);
     }
 
     /**
@@ -56,7 +59,15 @@ public class DeleteDataObjectRequest extends WriteDataObjectRequest<DeleteDataOb
          */
         public DeleteDataObjectRequest build() {
             WriteDataObjectRequest.validateSeqNoAndPrimaryTerm(this.ifSeqNo, this.ifPrimaryTerm, false);
-            return new DeleteDataObjectRequest(this.index, this.id, this.tenantId, this.ifSeqNo, this.ifPrimaryTerm, this.refreshPolicy);
+            return new DeleteDataObjectRequest(
+                this.index,
+                this.id,
+                this.tenantId,
+                this.ifSeqNo,
+                this.ifPrimaryTerm,
+                this.refreshPolicy,
+                this.timeout
+            );
         }
     }
 }

--- a/core/src/main/java/org/opensearch/remote/metadata/client/PutDataObjectRequest.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/PutDataObjectRequest.java
@@ -9,6 +9,7 @@
 package org.opensearch.remote.metadata.client;
 
 import org.opensearch.action.support.WriteRequest.RefreshPolicy;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.xcontent.ToXContentObject;
 
 import java.util.Map;
@@ -30,7 +31,8 @@ public class PutDataObjectRequest extends WriteDataObjectRequest<PutDataObjectRe
      * @param tenantId the tenant id
      * @param ifSeqNo the sequence number to match or null if not required
      * @param ifPrimaryTerm the primary term to match or null if not required
-     * @param refreshPolicy when should the written data be refreshed. May not be applicable on all clients.
+     * @param refreshPolicy when should the written data be refreshed. May not be applicable on all clients. Defaults to {@code IMMEDIATE}.
+     * @param timeout A timeout to wait if the index operation can't be performed immediately. May not be applicable on all clients. Defaults to {@code 1m}.
      * @param overwriteIfExists whether to overwrite the document if it exists (update)
      * @param dataObject the data object
      */
@@ -41,10 +43,11 @@ public class PutDataObjectRequest extends WriteDataObjectRequest<PutDataObjectRe
         Long ifSeqNo,
         Long ifPrimaryTerm,
         RefreshPolicy refreshPolicy,
+        TimeValue timeout,
         boolean overwriteIfExists,
         ToXContentObject dataObject
     ) {
-        super(index, id, tenantId, ifSeqNo, ifPrimaryTerm, refreshPolicy, !overwriteIfExists);
+        super(index, id, tenantId, ifSeqNo, ifPrimaryTerm, refreshPolicy, timeout, !overwriteIfExists);
         this.overwriteIfExists = overwriteIfExists;
         this.dataObject = dataObject;
     }
@@ -128,6 +131,7 @@ public class PutDataObjectRequest extends WriteDataObjectRequest<PutDataObjectRe
                 this.ifSeqNo,
                 this.ifPrimaryTerm,
                 this.refreshPolicy,
+                this.timeout,
                 this.overwriteIfExists,
                 this.dataObject
             );

--- a/core/src/main/java/org/opensearch/remote/metadata/client/PutDataObjectRequest.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/PutDataObjectRequest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * A class abstracting an OpenSearch IndexRequest
  */
-public class PutDataObjectRequest extends WriteDataObjectRequest {
+public class PutDataObjectRequest extends WriteDataObjectRequest<PutDataObjectRequest> {
 
     private final boolean overwriteIfExists;
     private final ToXContentObject dataObject;

--- a/core/src/main/java/org/opensearch/remote/metadata/client/PutDataObjectRequest.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/PutDataObjectRequest.java
@@ -8,6 +8,7 @@
  */
 package org.opensearch.remote.metadata.client;
 
+import org.opensearch.action.support.WriteRequest.RefreshPolicy;
 import org.opensearch.core.xcontent.ToXContentObject;
 
 import java.util.Map;
@@ -29,6 +30,7 @@ public class PutDataObjectRequest extends WriteDataObjectRequest {
      * @param tenantId the tenant id
      * @param ifSeqNo the sequence number to match or null if not required
      * @param ifPrimaryTerm the primary term to match or null if not required
+     * @param refreshPolicy when should the written data be refreshed. May not be applicable on all clients.
      * @param overwriteIfExists whether to overwrite the document if it exists (update)
      * @param dataObject the data object
      */
@@ -38,10 +40,11 @@ public class PutDataObjectRequest extends WriteDataObjectRequest {
         String tenantId,
         Long ifSeqNo,
         Long ifPrimaryTerm,
+        RefreshPolicy refreshPolicy,
         boolean overwriteIfExists,
         ToXContentObject dataObject
     ) {
-        super(index, id, tenantId, ifSeqNo, ifPrimaryTerm, !overwriteIfExists);
+        super(index, id, tenantId, ifSeqNo, ifPrimaryTerm, refreshPolicy, !overwriteIfExists);
         this.overwriteIfExists = overwriteIfExists;
         this.dataObject = dataObject;
     }
@@ -124,6 +127,7 @@ public class PutDataObjectRequest extends WriteDataObjectRequest {
                 this.tenantId,
                 this.ifSeqNo,
                 this.ifPrimaryTerm,
+                this.refreshPolicy,
                 this.overwriteIfExists,
                 this.dataObject
             );

--- a/core/src/main/java/org/opensearch/remote/metadata/client/UpdateDataObjectRequest.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/UpdateDataObjectRequest.java
@@ -9,6 +9,7 @@
 package org.opensearch.remote.metadata.client;
 
 import org.opensearch.action.support.WriteRequest.RefreshPolicy;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 
@@ -32,7 +33,8 @@ public class UpdateDataObjectRequest extends WriteDataObjectRequest<UpdateDataOb
      * @param tenantId the tenant id
      * @param ifSeqNo the sequence number to match or null if not required
      * @param ifPrimaryTerm the primary term to match or null if not required
-     * @param refreshPolicy when should the written data be refreshed. May not be applicable on all clients.
+     * @param refreshPolicy when should the written data be refreshed. May not be applicable on all clients. Defaults to {@code IMMEDIATE}.
+     * @param timeout A timeout to wait if the index operation can't be performed immediately. May not be applicable on all clients. Defaults to {@code 1m}.
      * @param retryOnConflict number of times to retry an update if a version conflict exists
      * @param dataObject the data object
      */
@@ -43,10 +45,11 @@ public class UpdateDataObjectRequest extends WriteDataObjectRequest<UpdateDataOb
         Long ifSeqNo,
         Long ifPrimaryTerm,
         RefreshPolicy refreshPolicy,
+        TimeValue timeout,
         int retryOnConflict,
         ToXContentObject dataObject
     ) {
-        super(index, id, tenantId, ifSeqNo, ifPrimaryTerm, refreshPolicy, false);
+        super(index, id, tenantId, ifSeqNo, ifPrimaryTerm, refreshPolicy, timeout, false);
         this.retryOnConflict = retryOnConflict;
         this.dataObject = dataObject;
     }
@@ -135,6 +138,7 @@ public class UpdateDataObjectRequest extends WriteDataObjectRequest<UpdateDataOb
                 this.ifSeqNo,
                 this.ifPrimaryTerm,
                 this.refreshPolicy,
+                this.timeout,
                 this.retryOnConflict,
                 this.dataObject
             );

--- a/core/src/main/java/org/opensearch/remote/metadata/client/UpdateDataObjectRequest.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/UpdateDataObjectRequest.java
@@ -18,7 +18,7 @@ import java.util.Map;
 /**
  * A class abstracting an OpenSearch UpdateRequest
  */
-public class UpdateDataObjectRequest extends WriteDataObjectRequest {
+public class UpdateDataObjectRequest extends WriteDataObjectRequest<UpdateDataObjectRequest> {
 
     private final int retryOnConflict;
     private final ToXContentObject dataObject;

--- a/core/src/main/java/org/opensearch/remote/metadata/client/UpdateDataObjectRequest.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/UpdateDataObjectRequest.java
@@ -8,6 +8,7 @@
  */
 package org.opensearch.remote.metadata.client;
 
+import org.opensearch.action.support.WriteRequest.RefreshPolicy;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 
@@ -31,6 +32,7 @@ public class UpdateDataObjectRequest extends WriteDataObjectRequest {
      * @param tenantId the tenant id
      * @param ifSeqNo the sequence number to match or null if not required
      * @param ifPrimaryTerm the primary term to match or null if not required
+     * @param refreshPolicy when should the written data be refreshed. May not be applicable on all clients.
      * @param retryOnConflict number of times to retry an update if a version conflict exists
      * @param dataObject the data object
      */
@@ -40,10 +42,11 @@ public class UpdateDataObjectRequest extends WriteDataObjectRequest {
         String tenantId,
         Long ifSeqNo,
         Long ifPrimaryTerm,
+        RefreshPolicy refreshPolicy,
         int retryOnConflict,
         ToXContentObject dataObject
     ) {
-        super(index, id, tenantId, ifSeqNo, ifPrimaryTerm, false);
+        super(index, id, tenantId, ifSeqNo, ifPrimaryTerm, refreshPolicy, false);
         this.retryOnConflict = retryOnConflict;
         this.dataObject = dataObject;
     }
@@ -131,6 +134,7 @@ public class UpdateDataObjectRequest extends WriteDataObjectRequest {
                 this.tenantId,
                 this.ifSeqNo,
                 this.ifPrimaryTerm,
+                this.refreshPolicy,
                 this.retryOnConflict,
                 this.dataObject
             );

--- a/core/src/main/java/org/opensearch/remote/metadata/client/WriteDataObjectRequest.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/WriteDataObjectRequest.java
@@ -9,6 +9,7 @@
 package org.opensearch.remote.metadata.client;
 
 import org.opensearch.action.support.WriteRequest.RefreshPolicy;
+import org.opensearch.common.unit.TimeValue;
 
 import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
 import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
@@ -20,6 +21,7 @@ public abstract class WriteDataObjectRequest<R extends WriteDataObjectRequest<R>
     protected final Long ifSeqNo;
     protected final Long ifPrimaryTerm;
     protected RefreshPolicy refreshPolicy = RefreshPolicy.IMMEDIATE;
+    protected TimeValue timeout = TimeValue.timeValueMinutes(1L);
 
     /**
      * Instantiate this request with an index, id, and concurrency information.
@@ -31,6 +33,7 @@ public abstract class WriteDataObjectRequest<R extends WriteDataObjectRequest<R>
      * @param ifSeqNo the sequence number to match or null if not required
      * @param ifPrimaryTerm the primary term to match or null if not required
      * @param refreshPolicy when should the written data be refreshed. May not be applicable on all clients. Defaults to {@code IMMEDIATE}.
+     * @param timeout A timeout to wait if the index operation can't be performed immediately. May not be applicable on all clients. Defaults to {@code 1m}.
      * @param isCreateOperation whether this can only create a new document and not overwrite one
      */
     protected WriteDataObjectRequest(
@@ -40,6 +43,7 @@ public abstract class WriteDataObjectRequest<R extends WriteDataObjectRequest<R>
         Long ifSeqNo,
         Long ifPrimaryTerm,
         RefreshPolicy refreshPolicy,
+        TimeValue timeout,
         boolean isCreateOperation
     ) {
         super(index, id, tenantId);
@@ -48,6 +52,9 @@ public abstract class WriteDataObjectRequest<R extends WriteDataObjectRequest<R>
         this.ifPrimaryTerm = ifPrimaryTerm;
         if (refreshPolicy != null) {
             this.refreshPolicy = refreshPolicy;
+        }
+        if (timeout != null) {
+            this.timeout = timeout;
         }
     }
 
@@ -86,6 +93,34 @@ public abstract class WriteDataObjectRequest<R extends WriteDataObjectRequest<R>
         return (R) this;
     }
 
+    /**
+     * A timeout to wait if the index operation can't be performed immediately. May not be applicable on all clients. Defaults to {@code 1m}.
+     * @param timeout The timeout to set
+     * @return the request after updating the timeout
+     */
+    @SuppressWarnings("unchecked")
+    public final R timeout(TimeValue timeout) {
+        this.timeout = timeout;
+        return (R) this;
+    }
+
+    /**
+     * A timeout to wait if the index operation can't be performed immediately. May not be applicable on all clients. Defaults to {@code 1m}.
+     * @param timeout The timeout to set
+     * @return the request after updating the timeout
+     */
+    public final R timeout(String timeout) {
+        return timeout(TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout"));
+    }
+
+    /**
+     * A timeout to wait if the index operation can't be performed immediately. May not be applicable on all clients. Defaults to {@code 1m}.
+     * @return the timeout
+     */
+    public TimeValue timeout() {
+        return timeout;
+    }
+
     @Override
     public boolean isWriteRequest() {
         return true;
@@ -98,6 +133,7 @@ public abstract class WriteDataObjectRequest<R extends WriteDataObjectRequest<R>
         protected Long ifSeqNo = null;
         protected Long ifPrimaryTerm = null;
         protected RefreshPolicy refreshPolicy = RefreshPolicy.IMMEDIATE;
+        protected TimeValue timeout = TimeValue.timeValueMinutes(1L);
 
         /**
          * Only perform this request if the document's modification was assigned the given
@@ -137,6 +173,25 @@ public abstract class WriteDataObjectRequest<R extends WriteDataObjectRequest<R>
             this.refreshPolicy = refreshPolicy;
             return self();
         }
+
+        /**
+         * A timeout to wait if the index operation can't be performed immediately. Defaults to {@code 1m}.
+         * @param timeout The timeout to set
+         * @return the request after updating the timeout
+         */
+        public T timeout(TimeValue timeout) {
+            this.timeout = timeout;
+            return self();
+        }
+
+        /**
+         * A timeout to wait if the index operation can't be performed immediately. Defaults to {@code 1m}.
+         * @param timeout The timeout to set
+         * @return the request after updating the timeout
+         */
+        public final T timeout(String timeout) {
+            return timeout(TimeValue.parseTimeValue(timeout, null, getClass().getSimpleName() + ".timeout"));
+        }
     }
 
     /**
@@ -164,5 +219,4 @@ public abstract class WriteDataObjectRequest<R extends WriteDataObjectRequest<R>
     private static boolean isUnassignedPrimaryTerm(Long primaryTerm) {
         return primaryTerm == null || primaryTerm == UNASSIGNED_PRIMARY_TERM;
     }
-
 }

--- a/core/src/main/java/org/opensearch/remote/metadata/client/WriteDataObjectRequest.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/WriteDataObjectRequest.java
@@ -16,7 +16,7 @@ import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 /**
  * An abstract class for write operations that support sequence numbers and primary terms
  */
-public abstract class WriteDataObjectRequest extends DataObjectRequest {
+public abstract class WriteDataObjectRequest<R extends WriteDataObjectRequest<R>> extends DataObjectRequest {
     protected final Long ifSeqNo;
     protected final Long ifPrimaryTerm;
     protected RefreshPolicy refreshPolicy = RefreshPolicy.IMMEDIATE;
@@ -30,7 +30,7 @@ public abstract class WriteDataObjectRequest extends DataObjectRequest {
      * @param tenantId the tenant id
      * @param ifSeqNo the sequence number to match or null if not required
      * @param ifPrimaryTerm the primary term to match or null if not required
-     * @param refreshPolicy when should the written data be refreshed. May not be applicable on all clients.
+     * @param refreshPolicy when should the written data be refreshed. May not be applicable on all clients. Defaults to {@code IMMEDIATE}.
      * @param isCreateOperation whether this can only create a new document and not overwrite one
      */
     protected WriteDataObjectRequest(
@@ -78,9 +78,12 @@ public abstract class WriteDataObjectRequest extends DataObjectRequest {
     /**
      * Sets the refresh policy.
      * @param refreshPolicy The policy to set
+     * @return a copy of the object after updating
      */
-    public void setRefreshPolicy(RefreshPolicy refreshPolicy) {
+    @SuppressWarnings("unchecked")
+    public R setRefreshPolicy(RefreshPolicy refreshPolicy) {
         this.refreshPolicy = refreshPolicy;
+        return (R) this;
     }
 
     @Override

--- a/core/src/main/java/org/opensearch/remote/metadata/client/WriteDataObjectRequest.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/WriteDataObjectRequest.java
@@ -124,6 +124,12 @@ public abstract class WriteDataObjectRequest extends DataObjectRequest {
             return self();
         }
 
+        /**
+         * Should this request trigger a refresh ({@linkplain RefreshPolicy#IMMEDIATE}), wait for a refresh (
+         * {@linkplain RefreshPolicy#WAIT_UNTIL}), or proceed ignore refreshes entirely ({@linkplain RefreshPolicy#NONE}, the default).
+         * @param refreshPolicy the policy to set
+         * @return the updated builder
+         */
         public T refreshPolicy(RefreshPolicy refreshPolicy) {
             this.refreshPolicy = refreshPolicy;
             return self();

--- a/core/src/main/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClient.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClient.java
@@ -148,7 +148,7 @@ public class LocalClusterIndicesClient extends AbstractSdkClient {
         }
     }
 
-    private <T extends DocWriteRequest<T>> T setSeqNoAndPrimaryTerm(T request, WriteDataObjectRequest writeRequest) {
+    private <T extends DocWriteRequest<T>, R extends WriteDataObjectRequest<R>> T setSeqNoAndPrimaryTerm(T request, R writeRequest) {
         if (writeRequest.ifSeqNo() != null) {
             request.setIfSeqNo(writeRequest.ifSeqNo());
         }

--- a/core/src/main/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClient.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClient.java
@@ -58,7 +58,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 
-import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
 import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
 import static org.opensearch.secure_sm.AccessController.doPrivileged;
 

--- a/core/src/test/java/org/opensearch/remote/metadata/client/BulkDataObjectRequestTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/BulkDataObjectRequestTests.java
@@ -49,16 +49,19 @@ public class BulkDataObjectRequestTests {
         assertTrue(r0 instanceof PutDataObjectRequest);
         assertEquals(testIndex, r0.index());
         assertNull(r0.tenantId());
+        assertEquals(RefreshPolicy.NONE, ((WriteDataObjectRequest) r0).getRefreshPolicy());
 
         DataObjectRequest r1 = request.requests().get(1);
         assertTrue(r1 instanceof UpdateDataObjectRequest);
         assertEquals(testGlobalIndex, r1.index());
         assertNull(r1.tenantId());
+        assertEquals(RefreshPolicy.NONE, ((WriteDataObjectRequest) r1).getRefreshPolicy());
 
         DataObjectRequest r2 = request.requests().get(2);
         assertTrue(r2 instanceof DeleteDataObjectRequest);
         assertEquals(testIndex, r2.index());
         assertEquals(testTenantId, r2.tenantId());
+        assertEquals(RefreshPolicy.NONE, ((WriteDataObjectRequest) r2).getRefreshPolicy());
     }
 
     @Test
@@ -75,11 +78,13 @@ public class BulkDataObjectRequestTests {
         assertTrue(r0 instanceof PutDataObjectRequest);
         assertEquals(testIndex, r0.index());
         assertEquals(testTenantId, r0.tenantId());
+        assertEquals(RefreshPolicy.NONE, ((WriteDataObjectRequest) r0).getRefreshPolicy());
 
         DataObjectRequest r1 = request.requests().get(1);
         assertTrue(r1 instanceof DeleteDataObjectRequest);
         assertEquals(testIndex, r1.index());
         assertEquals(testTenantId, r1.tenantId());
+        assertEquals(RefreshPolicy.NONE, ((WriteDataObjectRequest) r1).getRefreshPolicy());
     }
 
     @SuppressWarnings("removal")

--- a/core/src/test/java/org/opensearch/remote/metadata/client/BulkDataObjectRequestTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/BulkDataObjectRequestTests.java
@@ -9,6 +9,7 @@
 package org.opensearch.remote.metadata.client;
 
 import org.opensearch.action.support.WriteRequest.RefreshPolicy;
+import org.opensearch.common.unit.TimeValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -39,37 +40,42 @@ public class BulkDataObjectRequestTests {
             .add(PutDataObjectRequest.builder().index(testIndex).build())
             .add(UpdateDataObjectRequest.builder().build())
             .add(DeleteDataObjectRequest.builder().index(testIndex).tenantId(testTenantId).build())
-            .setRefreshPolicy(RefreshPolicy.IMMEDIATE);
+            .setRefreshPolicy(RefreshPolicy.IMMEDIATE)
+            .timeout("30s");
 
         assertEquals(Set.of(testIndex, testGlobalIndex), request.getIndices());
         assertEquals(3, request.requests().size());
         assertEquals(RefreshPolicy.IMMEDIATE, request.getRefreshPolicy());
+        assertEquals(TimeValue.timeValueSeconds(30L), request.timeout());
 
         DataObjectRequest r0 = request.requests().get(0);
         assertTrue(r0 instanceof PutDataObjectRequest);
         assertEquals(testIndex, r0.index());
         assertNull(r0.tenantId());
-        assertEquals(RefreshPolicy.NONE, ((WriteDataObjectRequest) r0).getRefreshPolicy());
+        assertEquals(RefreshPolicy.NONE, ((WriteDataObjectRequest<?>) r0).getRefreshPolicy());
+        assertEquals(TimeValue.timeValueMinutes(1L), ((WriteDataObjectRequest<?>) r0).timeout());
 
         DataObjectRequest r1 = request.requests().get(1);
         assertTrue(r1 instanceof UpdateDataObjectRequest);
         assertEquals(testGlobalIndex, r1.index());
         assertNull(r1.tenantId());
-        assertEquals(RefreshPolicy.NONE, ((WriteDataObjectRequest) r1).getRefreshPolicy());
+        assertEquals(RefreshPolicy.NONE, ((WriteDataObjectRequest<?>) r1).getRefreshPolicy());
+        assertEquals(TimeValue.timeValueMinutes(1L), ((WriteDataObjectRequest<?>) r1).timeout());
 
         DataObjectRequest r2 = request.requests().get(2);
         assertTrue(r2 instanceof DeleteDataObjectRequest);
         assertEquals(testIndex, r2.index());
         assertEquals(testTenantId, r2.tenantId());
-        assertEquals(RefreshPolicy.NONE, ((WriteDataObjectRequest) r2).getRefreshPolicy());
+        assertEquals(RefreshPolicy.NONE, ((WriteDataObjectRequest<?>) r2).getRefreshPolicy());
+        assertEquals(TimeValue.timeValueMinutes(1L), ((WriteDataObjectRequest<?>) r2).timeout());
     }
 
     @Test
     public void testBulkDataObjectRequest_Tenant() {
         BulkDataObjectRequest request = BulkDataObjectRequest.builder()
             .build()
-            .add(PutDataObjectRequest.builder().index(testIndex).tenantId(testTenantId).build())
-            .add(DeleteDataObjectRequest.builder().index(testIndex).tenantId(testTenantId).build());
+            .add(PutDataObjectRequest.builder().index(testIndex).tenantId(testTenantId).timeout(TimeValue.timeValueSeconds(45)).build())
+            .add(DeleteDataObjectRequest.builder().index(testIndex).tenantId(testTenantId).timeout("30s").build());
 
         assertEquals(Set.of(testIndex), request.getIndices());
         assertEquals(2, request.requests().size());
@@ -78,13 +84,15 @@ public class BulkDataObjectRequestTests {
         assertTrue(r0 instanceof PutDataObjectRequest);
         assertEquals(testIndex, r0.index());
         assertEquals(testTenantId, r0.tenantId());
-        assertEquals(RefreshPolicy.NONE, ((WriteDataObjectRequest) r0).getRefreshPolicy());
+        assertEquals(RefreshPolicy.NONE, ((PutDataObjectRequest) r0).getRefreshPolicy());
+        assertEquals(TimeValue.timeValueSeconds(45L), ((PutDataObjectRequest) r0).timeout());
 
         DataObjectRequest r1 = request.requests().get(1);
         assertTrue(r1 instanceof DeleteDataObjectRequest);
         assertEquals(testIndex, r1.index());
         assertEquals(testTenantId, r1.tenantId());
-        assertEquals(RefreshPolicy.NONE, ((WriteDataObjectRequest) r1).getRefreshPolicy());
+        assertEquals(RefreshPolicy.NONE, ((DeleteDataObjectRequest) r1).getRefreshPolicy());
+        assertEquals(TimeValue.timeValueSeconds(30L), ((DeleteDataObjectRequest) r1).timeout());
     }
 
     @SuppressWarnings("removal")

--- a/core/src/test/java/org/opensearch/remote/metadata/client/DeleteDataObjectRequestTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/DeleteDataObjectRequestTests.java
@@ -8,6 +8,8 @@
  */
 package org.opensearch.remote.metadata.client;
 
+import org.opensearch.action.support.WriteRequest.RefreshPolicy;
+import org.opensearch.common.unit.TimeValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -40,6 +42,8 @@ public class DeleteDataObjectRequestTests {
         assertEquals(testTenantId, request.tenantId());
         assertNull(request.ifSeqNo());
         assertNull(request.ifPrimaryTerm());
+        assertEquals(RefreshPolicy.IMMEDIATE, request.getRefreshPolicy());
+        assertEquals(TimeValue.timeValueMinutes(1L), request.timeout());
     }
 
     @Test
@@ -50,6 +54,8 @@ public class DeleteDataObjectRequestTests {
             .tenantId(testTenantId)
             .ifSeqNo(testSeqNo)
             .ifPrimaryTerm(testPrimaryTerm)
+            .refreshPolicy(RefreshPolicy.NONE)
+            .timeout("30s")
             .build();
 
         assertEquals(testIndex, request.index());
@@ -57,6 +63,8 @@ public class DeleteDataObjectRequestTests {
         assertEquals(testTenantId, request.tenantId());
         assertEquals(testSeqNo, request.ifSeqNo());
         assertEquals(testPrimaryTerm, request.ifPrimaryTerm());
+        assertEquals(RefreshPolicy.NONE, request.getRefreshPolicy());
+        assertEquals(TimeValue.timeValueSeconds(30L), request.timeout());
 
         final DeleteDataObjectRequest.Builder badSeqNoBuilder = DeleteDataObjectRequest.builder();
         assertThrows(IllegalArgumentException.class, () -> badSeqNoBuilder.ifSeqNo(-99));

--- a/core/src/test/java/org/opensearch/remote/metadata/client/PutDataObjectRequestTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/PutDataObjectRequestTests.java
@@ -117,7 +117,7 @@ public class PutDataObjectRequestTests {
         assertThrows(IllegalArgumentException.class, () -> notOverwriteWithSeqNoBuilder.ifSeqNo(testSeqNo).build());
         assertThrows(
             IllegalArgumentException.class,
-            () -> new PutDataObjectRequest(testIndex, testId, testTenantId, 1L, 0L, false, testDataObject)
+            () -> new PutDataObjectRequest(testIndex, testId, testTenantId, 1L, 0L, null, false, testDataObject)
         );
         final Builder badSeqNoBuilder = PutDataObjectRequest.builder();
         assertThrows(IllegalArgumentException.class, () -> badSeqNoBuilder.ifSeqNo(-99));

--- a/core/src/test/java/org/opensearch/remote/metadata/client/PutDataObjectRequestTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/PutDataObjectRequestTests.java
@@ -8,6 +8,8 @@
  */
 package org.opensearch.remote.metadata.client;
 
+import org.opensearch.action.support.WriteRequest.RefreshPolicy;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentType;
@@ -62,6 +64,8 @@ public class PutDataObjectRequestTests {
         assertSame(testDataObject, request.dataObject());
         assertNull(request.ifSeqNo());
         assertNull(request.ifPrimaryTerm());
+        assertEquals(RefreshPolicy.IMMEDIATE, request.getRefreshPolicy());
+        assertEquals(TimeValue.timeValueMinutes(1L), request.timeout());
 
         builder.overwriteIfExists(false);
         request = builder.build();
@@ -72,7 +76,13 @@ public class PutDataObjectRequestTests {
     public void testPutDataObjectRequestWithMap() throws IOException {
         Map<String, Object> dataObjectMap = Map.of("key1", "value1", "key2", "value2");
 
-        Builder builder = PutDataObjectRequest.builder().index(testIndex).id(testId).tenantId(testTenantId).dataObject(dataObjectMap);
+        Builder builder = PutDataObjectRequest.builder()
+            .index(testIndex)
+            .id(testId)
+            .tenantId(testTenantId)
+            .dataObject(dataObjectMap)
+            .refreshPolicy(RefreshPolicy.NONE)
+            .timeout("30s");
         PutDataObjectRequest request = builder.build();
 
         // Verify the index, id, tenantId, and overwriteIfExists fields
@@ -82,6 +92,8 @@ public class PutDataObjectRequestTests {
         assertTrue(request.overwriteIfExists());
         assertNull(request.ifSeqNo());
         assertNull(request.ifPrimaryTerm());
+        assertEquals(RefreshPolicy.NONE, request.getRefreshPolicy());
+        assertEquals(TimeValue.timeValueSeconds(30L), request.timeout());
 
         // Verify the dataObject field by converting it back to a Map and comparing
         ToXContentObject dataObject = request.dataObject();
@@ -117,7 +129,7 @@ public class PutDataObjectRequestTests {
         assertThrows(IllegalArgumentException.class, () -> notOverwriteWithSeqNoBuilder.ifSeqNo(testSeqNo).build());
         assertThrows(
             IllegalArgumentException.class,
-            () -> new PutDataObjectRequest(testIndex, testId, testTenantId, 1L, 0L, null, false, testDataObject)
+            () -> new PutDataObjectRequest(testIndex, testId, testTenantId, 1L, 0L, null, null, false, testDataObject)
         );
         final Builder badSeqNoBuilder = PutDataObjectRequest.builder();
         assertThrows(IllegalArgumentException.class, () -> badSeqNoBuilder.ifSeqNo(-99));

--- a/core/src/test/java/org/opensearch/remote/metadata/client/UpdateDataObjectRequestTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/UpdateDataObjectRequestTests.java
@@ -8,6 +8,8 @@
  */
 package org.opensearch.remote.metadata.client;
 
+import org.opensearch.action.support.WriteRequest.RefreshPolicy;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.XContentHelper;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.common.xcontent.json.JsonXContent;
@@ -60,6 +62,8 @@ public class UpdateDataObjectRequestTests {
         assertEquals(testDataObject, request.dataObject());
         assertNull(request.ifSeqNo());
         assertNull(request.ifPrimaryTerm());
+        assertEquals(RefreshPolicy.IMMEDIATE, request.getRefreshPolicy());
+        assertEquals(TimeValue.timeValueMinutes(1L), request.timeout());
         assertEquals(0, request.retryOnConflict());
     }
 
@@ -70,6 +74,8 @@ public class UpdateDataObjectRequestTests {
             .id(testId)
             .tenantId(testTenantId)
             .dataObject(testDataObjectMap)
+            .refreshPolicy(RefreshPolicy.NONE)
+            .timeout("30s")
             .build();
 
         assertEquals(testIndex, request.index());
@@ -79,6 +85,8 @@ public class UpdateDataObjectRequestTests {
             testDataObjectMap,
             XContentHelper.convertToMap(JsonXContent.jsonXContent, Strings.toString(XContentType.JSON, request.dataObject()), false)
         );
+        assertEquals(RefreshPolicy.NONE, request.getRefreshPolicy());
+        assertEquals(TimeValue.timeValueSeconds(30L), request.timeout());
     }
 
     @Test

--- a/core/src/test/java/org/opensearch/remote/metadata/client/WriteDataObjectRequestTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/WriteDataObjectRequestTests.java
@@ -26,7 +26,7 @@ public class WriteDataObjectRequestTests {
     private static final String TEST_TENANT_ID = "test-tenant";
 
     // Concrete implementation for testing
-    private static class TestWriteRequest extends WriteDataObjectRequest {
+    private static class TestWriteRequest extends WriteDataObjectRequest<TestWriteRequest> {
         TestWriteRequest(String index, String id, String tenantId, Long ifSeqNo, Long ifPrimaryTerm, RefreshPolicy refreshPolicy) {
             super(index, id, tenantId, ifSeqNo, ifPrimaryTerm, refreshPolicy, false);
         }
@@ -134,12 +134,27 @@ public class WriteDataObjectRequestTests {
     }
 
     @Test
+    public void testRefreshPolicyBuilderDefault() {
+        TestWriteRequest request = TestWriteRequest.builder().index(TEST_INDEX).id(TEST_ID).tenantId(TEST_TENANT_ID).build();
+        assertEquals(RefreshPolicy.IMMEDIATE, request.getRefreshPolicy());
+
+        request = TestWriteRequest.builder()
+            .index(TEST_INDEX)
+            .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
+            .refreshPolicy(RefreshPolicy.NONE)
+            .build();
+        assertEquals(RefreshPolicy.NONE, request.getRefreshPolicy());
+    }
+
+    @Test
     public void testRefreshPolicyExplicit() {
         TestWriteRequest request = new TestWriteRequest(TEST_INDEX, TEST_ID, TEST_TENANT_ID, null, null, RefreshPolicy.NONE);
         assertEquals(RefreshPolicy.NONE, request.getRefreshPolicy());
 
         request.setRefreshPolicy(RefreshPolicy.WAIT_UNTIL);
         assertEquals(RefreshPolicy.WAIT_UNTIL, request.getRefreshPolicy());
-    }
 
+        assertEquals(RefreshPolicy.IMMEDIATE, request.setRefreshPolicy(RefreshPolicy.IMMEDIATE).getRefreshPolicy());
+    }
 }


### PR DESCRIPTION
### Description

Adds support for RefreshPolicy, part of `DocWriteRequest`/`WriteRequest` implementations and timeout, part of ` ReplicatedWriteRequest`/`ReplicationRequest` (Index and Delete) or `InstanceShardOperationRequest` (Update) implementations.
 - Added support for the individual requests, defaulting to IMMEDIATE (matching existing) for refresh policy and "1m" for the timeout.
 - Added support for the bulk request handling (requiring NONE for the item request)
 - Implemented on Local Client
 - Implemented on Remote Client (bulk item requests are already handled)
 - Did not do any DDB implementation as this concept doesn't exist. There is a setting for strong consistency on reads (Get) but nothing associated with writes.

### Issues Resolved
 - Fixes #178 
 - Supercedes #137

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
