### PR TITLE
Fix Maven Snapshot Publishing for Gradle 9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ buildscript {
 
     repositories {
         mavenLocal()
-        maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
+        maven { url = "https://central.sonatype.com/repository/maven-snapshots/" }
         maven { url = "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
         maven { url = "https://plugins.gradle.org/m2/" }
@@ -53,7 +53,7 @@ allprojects {
 
     repositories {
         mavenLocal()
-        maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
+        maven { url = "https://central.sonatype.com/repository/maven-snapshots/" }
         maven { url = "https://aws.oss.sonatype.org/content/repositories/snapshots" }
         mavenCentral()
         maven { url = "https://plugins.gradle.org/m2/" }
@@ -213,8 +213,8 @@ subprojects {
                 name = "Snapshots"
                 url = "https://central.sonatype.com/repository/maven-snapshots/"
                 credentials {
-                    username = "$System.env.SONATYPE_USERNAME"
-                    password = "$System.env.SONATYPE_PASSWORD"
+                    username = System.getenv("SONATYPE_USERNAME")
+                    password = System.getenv("SONATYPE_PASSWORD")
                 }
             }
         }


### PR DESCRIPTION
### Description

Upgrading to Gradle 9 [broke snapshot publishing](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/actions/runs/17023398832/job/48255946880) with a 401 (Unauthorized) error.

The root cause was that the `$System.env` format used for the Sonatype credentials is no longer supported:
```groovy
credentials {
    username = "$System.env.SONATYPE_USERNAME"
    password = "$System.env.SONATYPE_PASSWORD"
}
```
Changed to a Gradle 9 compatible version
```groovy
credentials {
    username = System.getenv("SONATYPE_USERNAME")
    password = System.getenv("SONATYPE_PASSWORD")
}
```

### Issues Resolved

Introduced in #27 where I copied this field from [somewhere else in the OpenSearch ecoystem](https://github.com/search?q=org%3Aopensearch-project+%24System.env.SONATYPE_USERNAME&type=code) where it should probably be updated as well (CC: @gaiksaya @peterzhuamazon @mch2).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
