### PR TITLE
Update argument type for ThreadContextAccess:doPrivileged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Maintenance
 ### Refactoring
 - Remove unneeded enum uppercase workaround ([#185](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/185))
+- Update argument type for ThreadContextAccess:doPrivileged ([#250](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/250))

--- a/core/src/main/java/org/opensearch/remote/metadata/client/AbstractSdkClient.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/AbstractSdkClient.java
@@ -23,7 +23,6 @@ import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.security.PrivilegedAction;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -31,6 +30,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
+import java.util.function.Supplier;
 
 import static org.opensearch.common.util.concurrent.ThreadContextAccess.doPrivileged;
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_ENDPOINT_KEY;
@@ -85,7 +85,7 @@ public abstract class AbstractSdkClient implements SdkClientDelegate {
      * @param executor the executor for the action
      * @return A {@link CompletionStage} encapsulating the completable future for the action
      */
-    protected <T> CompletionStage<T> executePrivilegedAsync(PrivilegedAction<T> action, Executor executor) {
+    protected <T> CompletionStage<T> executePrivilegedAsync(Supplier<T> action, Executor executor) {
         return CompletableFuture.supplyAsync(() -> doPrivileged(action), executor);
     }
 

--- a/core/src/test/java/org/opensearch/remote/metadata/client/SdkClientTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/SdkClientTests.java
@@ -14,7 +14,6 @@ import org.opensearch.core.rest.RestStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.security.PrivilegedAction;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -23,6 +22,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -421,7 +421,7 @@ public class SdkClientTests {
 
     @Test
     public void testExecutePrivilegedAsync() throws Exception {
-        PrivilegedAction<String> action = () -> "Test Result";
+        Supplier<String> action = () -> "Test Result";
         Executor executor = Executors.newCachedThreadPool();
         CompletionStage<String> result = sdkClientImpl.executePrivilegedAsync(action, executor);
         CompletableFuture<String> future = result.toCompletableFuture();
@@ -432,7 +432,7 @@ public class SdkClientTests {
 
     @Test
     public void testExecutePrivilegedAsyncWithException() throws Exception {
-        PrivilegedAction<String> action = () -> { throw new RuntimeException("Test Exception"); };
+        Supplier<String> action = () -> { throw new RuntimeException("Test Exception"); };
         Executor executor = Executors.newCachedThreadPool();
         CompletionStage<String> result = sdkClientImpl.executePrivilegedAsync(action, executor);
         CompletableFuture<String> future = result.toCompletableFuture();


### PR DESCRIPTION
### Description

Updates the argument type for `ThreadContextAccess.doPrivileged()` to align with https://github.com/opensearch-project/OpenSearch/pull/19239

### Issues Resolved

`java.lang.NoSuchMethodError: 'java.lang.Object org.opensearch.common.util.concurrent.ThreadContextAccess.doPrivileged(java.security.PrivilegedAction)'` in downstream repos.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
