### PR TITLE
Fix empty string init value for global resource cache ttl issue

### DIFF
--- a/core/src/main/java/org/opensearch/remote/metadata/client/AbstractSdkClient.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/AbstractSdkClient.java
@@ -18,6 +18,7 @@ import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.common.Strings;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentParser;
@@ -73,6 +74,7 @@ public abstract class AbstractSdkClient implements SdkClientDelegate {
 
         globalTenantId = metadataSettings.get(REMOTE_METADATA_GLOBAL_TENANT_ID_KEY);
         globalResourceCacheTTL = Optional.ofNullable(metadataSettings.get(REMOTE_METADATA_GLOBAL_RESOURCE_CACHE_TTL_KEY))
+            .filter(x -> !Strings.isNullOrEmpty(x))
             .map(x -> TimeValue.parseTimeValue(x, DEFAULT_GLOBAL_RESOURCE_CACHE_TTL, REMOTE_METADATA_GLOBAL_RESOURCE_CACHE_TTL_KEY))
             .filter(x -> x.getMillis() >= 0)
             .orElse(DEFAULT_GLOBAL_RESOURCE_CACHE_TTL);

--- a/core/src/test/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClientTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClientTests.java
@@ -968,6 +968,7 @@ public class LocalClusterIndicesClientTests {
     public void test_initialize() {
         innerClient.initialize(Map.of(REMOTE_METADATA_GLOBAL_RESOURCE_CACHE_TTL_KEY, "1ms"));
         innerClient.initialize(Map.of(REMOTE_METADATA_GLOBAL_RESOURCE_CACHE_TTL_KEY, "-1ms"));
+        innerClient.initialize(Map.of(REMOTE_METADATA_GLOBAL_RESOURCE_CACHE_TTL_KEY, ""));
     }
 
     @Test


### PR DESCRIPTION
### Description
In OpenSearch, a string type setting's default value is [`""`](https://github.com/opensearch-project/OpenSearch/blob/73a431607ceeb639614b1e924290842387f137eb/server/src/main/java/org/opensearch/common/settings/Setting.java#L1992-L1997)
And parsing this default value throws exception, this change is to handle this case to use default value.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
