### PR TITLE
Fix no such method issue when running ml-common integTest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Refactoring
 - Remove unneeded enum uppercase workaround ([#185](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/185))
 - Update argument type for ThreadContextAccess:doPrivileged ([#250](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/250))
+- Use AccessController instead of ThreadContextAccess as it's for internal use ([#254](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/254))

--- a/aos-client/src/main/java/org/opensearch/remote/metadata/client/impl/AOSOpenSearchClient.java
+++ b/aos-client/src/main/java/org/opensearch/remote/metadata/client/impl/AOSOpenSearchClient.java
@@ -25,9 +25,9 @@ import org.opensearch.remote.metadata.client.SdkClient;
 
 import java.util.Map;
 
-import static org.opensearch.common.util.concurrent.ThreadContextAccess.doPrivileged;
 import static org.opensearch.remote.metadata.common.CommonValue.AWS_OPENSEARCH_SERVICE;
 import static org.opensearch.remote.metadata.common.CommonValue.VALID_AWS_OPENSEARCH_SERVICE_NAMES;
+import static org.opensearch.secure_sm.AccessController.doPrivileged;
 
 /**
  * An implementation of {@link SdkClient} that stores data in a remote

--- a/core/src/main/java/org/opensearch/remote/metadata/client/AbstractSdkClient.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/AbstractSdkClient.java
@@ -33,7 +33,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
 
-import static org.opensearch.common.util.concurrent.ThreadContextAccess.doPrivileged;
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_ENDPOINT_KEY;
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_GLOBAL_RESOURCE_CACHE_TTL_KEY;
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_GLOBAL_TENANT_ID_KEY;
@@ -41,6 +40,7 @@ import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_SERVICE_NAME_KEY;
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_TYPE_KEY;
 import static org.opensearch.remote.metadata.common.CommonValue.TENANT_ID_FIELD_KEY;
+import static org.opensearch.secure_sm.AccessController.doPrivileged;
 
 /**
  * Superclass abstracting privileged action execution

--- a/core/src/main/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClient.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClient.java
@@ -59,8 +59,8 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 
 import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
-import static org.opensearch.common.util.concurrent.ThreadContextAccess.doPrivileged;
 import static org.opensearch.core.xcontent.ToXContent.EMPTY_PARAMS;
+import static org.opensearch.secure_sm.AccessController.doPrivileged;
 
 /**
  * An implementation of {@link SdkClient} that stores data in a local OpenSearch

--- a/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClient.java
+++ b/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClient.java
@@ -90,11 +90,11 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static org.opensearch.common.util.concurrent.ThreadContextAccess.doPrivileged;
 import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_PRIMARY_TERM;
 import static org.opensearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 import static org.opensearch.remote.metadata.common.CommonValue.AWS_DYNAMO_DB;
 import static org.opensearch.remote.metadata.common.CommonValue.VALID_AWS_OPENSEARCH_SERVICE_NAMES;
+import static org.opensearch.secure_sm.AccessController.doPrivileged;
 
 /**
  * DDB implementation of {@link SdkClient}. DDB table name will be mapped to index name.

--- a/remote-client/src/main/java/org/opensearch/remote/metadata/client/impl/RemoteClusterIndicesClient.java
+++ b/remote-client/src/main/java/org/opensearch/remote/metadata/client/impl/RemoteClusterIndicesClient.java
@@ -95,9 +95,9 @@ import java.util.concurrent.Executor;
 import jakarta.json.stream.JsonGenerator;
 import jakarta.json.stream.JsonParser;
 
-import static org.opensearch.common.util.concurrent.ThreadContextAccess.doPrivileged;
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_OPENSEARCH;
 import static org.opensearch.remote.metadata.common.CommonValue.TENANT_ID_FIELD_KEY;
+import static org.opensearch.secure_sm.AccessController.doPrivileged;
 
 /**
  * An implementation of {@link SdkClient} that stores data in a remote


### PR DESCRIPTION
### Description
As confirmed, we should use AccessController instead of ThreadContextAccess as it's for internal use.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
