### PR TITLE
Exclude commons-lang3 from checkstyle transitive dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,12 +79,14 @@ allprojects {
         toolVersion = "latest.release"
     }
 
-    // Fix for CVE-2025-27820 and WS-2019-0379
     configurations.checkstyle {
+        // Fix for CVE-2025-27820 and WS-2019-0379
         exclude group: 'org.apache.httpcomponents.client5', module: 'httpclient5'
         exclude group: 'org.apache.httpcomponents.core5', module: 'httpcore5'
         exclude group: 'org.apache.httpcomponents', module: 'httpclient'
         exclude group: 'org.apache.httpcomponents', module: 'httpcore'
+        // Fix for CVE-2025-48924
+        exclude group: 'org.apache.commons', module: 'commons-lang3'
     }
 }
 


### PR DESCRIPTION
### Description

Excludes `org.apache.commons:commons-lang3` from transitive import via checkstyle, where it's currently importing CVE-impacted version 3.8.1.

### Issues Resolved

Resolves [CVE-2025-48924](https://nvd.nist.gov/vuln/detail/CVE-2025-48924)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
