### PR TITLE
Fix global tenant id not set  default value bypassing issue

### DIFF
--- a/core/src/main/java/org/opensearch/remote/metadata/client/AbstractSdkClient.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/AbstractSdkClient.java
@@ -195,7 +195,7 @@ public abstract class AbstractSdkClient implements SdkClientDelegate {
 
     @Override
     public CompletionStage<Boolean> isGlobalResource(String index, String id, Executor executor, Boolean isMultiTenancyEnabled) {
-        if (Boolean.FALSE.equals(isMultiTenancyEnabled) || globalTenantId == null) {
+        if (Boolean.FALSE.equals(isMultiTenancyEnabled) || Strings.isNullOrEmpty(globalTenantId)) {
             return CompletableFuture.completedFuture(false);
         }
         GetDataObjectRequest request = GetDataObjectRequest.builder().index(index).id(id).tenantId(globalTenantId).build();

--- a/core/src/main/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClient.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClient.java
@@ -166,7 +166,7 @@ public class LocalClusterIndicesClient extends AbstractSdkClient {
         Boolean isMultiTenancyEnabled
     ) {
         return doPrivileged(() -> {
-            if (Boolean.FALSE.equals(isMultiTenancyEnabled) || globalTenantId == null) {
+            if (Boolean.FALSE.equals(isMultiTenancyEnabled) || Strings.isNullOrEmpty(globalTenantId)) {
                 return innerGetDataObjectAsync(request, executor, isMultiTenancyEnabled);
             }
 

--- a/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClient.java
+++ b/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClient.java
@@ -283,7 +283,7 @@ public class DDBOpenSearchClient extends AbstractSdkClient {
         Executor executor,
         Boolean isMultiTenancyEnabled
     ) {
-        if (Boolean.FALSE.equals(isMultiTenancyEnabled) || globalTenantId == null) {
+        if (Boolean.FALSE.equals(isMultiTenancyEnabled) || Strings.isNullOrEmpty(globalTenantId)) {
             return innerGetDataObjectAsync(request, executor, isMultiTenancyEnabled);
         }
         // Try fetch from global cache.

--- a/ddb-client/src/test/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClientTests.java
+++ b/ddb-client/src/test/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClientTests.java
@@ -1237,6 +1237,19 @@ public class DDBOpenSearchClientTests {
     }
 
     @Test
+    public void testGetDataObject_globalTenantIdDisabled_fetchNonExistsResource_noException() {
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).tenantId(TEST_TENANT_ID).build();
+        Map<String, AttributeValue> itemResponse = new HashMap<>();
+        GetItemResponse getItemResponse = GetItemResponse.builder().item(itemResponse).build();
+        when(dynamoDbAsyncClient.getItem(any(GetItemRequest.class))).thenReturn(CompletableFuture.completedFuture(getItemResponse));
+        GetDataObjectResponse getDataObjectResponse = sdkClient.getDataObjectAsync(getRequest, testThreadPool.executor(TEST_THREAD_POOL))
+            .toCompletableFuture()
+            .join();
+        verify(dynamoDbAsyncClient, times(1)).getItem(getItemRequestArgumentCaptor.capture());
+        assertFalse(getDataObjectResponse.getResponse().isExists());
+    }
+
+    @Test
     public void testGetDataObject_globalTenantIdEnabled_foundGlobalResourceFromCache() {
         GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).tenantId(TEST_TENANT_ID).build();
         GetItemResponse itemNotExistResponse = GetItemResponse.builder().build();

--- a/remote-client/src/main/java/org/opensearch/remote/metadata/client/impl/RemoteClusterIndicesClient.java
+++ b/remote-client/src/main/java/org/opensearch/remote/metadata/client/impl/RemoteClusterIndicesClient.java
@@ -244,7 +244,7 @@ public class RemoteClusterIndicesClient extends AbstractSdkClient {
         Executor executor,
         Boolean isMultiTenancyEnabled
     ) {
-        if (Boolean.FALSE.equals(isMultiTenancyEnabled) || globalTenantId == null) {
+        if (Boolean.FALSE.equals(isMultiTenancyEnabled) || Strings.isNullOrEmpty(globalTenantId)) {
             return innerGetDataObjectAsync(request, executor, isMultiTenancyEnabled);
         }
         // First check cache for global resource


### PR DESCRIPTION
### Description
In OpenSearch, a string type setting's default value is [""](https://github.com/opensearch-project/OpenSearch/blob/73a431607ceeb639614b1e924290842387f137eb/server/src/main/java/org/opensearch/common/settings/Setting.java#L1992-L1997)
And this bypassed the checking for global tenant id not set case.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
