### PR TITLE
[Backport 2.19] Onboarding new maven snapshots publishing to s3 (opensearch-remote-metadata-sdk)

### DIFF
--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -31,8 +31,14 @@ jobs:
           export-env: true
         env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          SONATYPE_USERNAME: op://opensearch-infra-secrets/maven-central-portal-credentials/username
-          SONATYPE_PASSWORD: op://opensearch-infra-secrets/maven-central-portal-credentials/password
+          MAVEN_SNAPSHOTS_S3_REPO: op://opensearch-infra-secrets/maven-snapshots-s3/repo
+          MAVEN_SNAPSHOTS_S3_ROLE: op://opensearch-infra-secrets/maven-snapshots-s3/role
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ env.MAVEN_SNAPSHOTS_S3_ROLE }}
+          aws-region: us-east-1
 
       - name: publish snapshots to maven
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,7 @@ buildscript {
 
     repositories {
         mavenLocal()
-        maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
-        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
+        maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
     }
@@ -53,8 +52,7 @@ allprojects {
 
     repositories {
         mavenLocal()
-        maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
-        maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
+        maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
         maven { url "https://artifacts.opensearch.org/releases/" }
@@ -207,10 +205,11 @@ subprojects {
             }
             maven {
                 name = "Snapshots"
-                url = "https://central.sonatype.com/repository/maven-snapshots/"
-                credentials {
-                    username "$System.env.SONATYPE_USERNAME"
-                    password "$System.env.SONATYPE_PASSWORD"
+                url = System.getenv("MAVEN_SNAPSHOTS_S3_REPO")
+                credentials(AwsCredentials) {
+                    accessKey = System.getenv("AWS_ACCESS_KEY_ID")
+                    secretKey = System.getenv("AWS_SECRET_ACCESS_KEY")
+                    sessionToken = System.getenv("AWS_SESSION_TOKEN")
                 }
             }
         }


### PR DESCRIPTION


### Description
[Backport 2.19] Onboarding new maven snapshots publishing to s3 (opensearch-remote-metadata-sdk)
Backport #267

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/5360

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
