### PR TITLE
upgrading netty codec version

### DIFF
--- a/ddb-client/build.gradle
+++ b/ddb-client/build.gradle
@@ -11,5 +11,8 @@ dependencies {
 
     implementation(platform("software.amazon.awssdk:bom:${versions.aws}"))
     implementation "software.amazon.awssdk:dynamodb"
-    implementation "software.amazon.awssdk:netty-nio-client"
+    implementation "software.amazon.awssdk:netty-nio-client:${versions.aws}"
+    implementation "io.netty:netty-codec-http:${versions.netty}"
+    implementation "io.netty:netty-codec-http2:${versions.netty}"
+    implementation "io.netty:netty-codec:${versions.netty}"
 }


### PR DESCRIPTION
### Description
upgrading netty codec version due to this CVE risk: CVE-2025-58057

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
