### PR TITLE
Fix error when updating model status

### DIFF
--- a/core/src/main/java/org/opensearch/remote/metadata/client/AbstractSdkClient.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/AbstractSdkClient.java
@@ -48,7 +48,7 @@ import static org.opensearch.secure_sm.AccessController.doPrivileged;
 public abstract class AbstractSdkClient implements SdkClientDelegate {
 
     // TENANT_ID hash key requires non-null value
-    public static final String DEFAULT_TENANT = "DEFAULT_TENANT";
+    protected static final String DEFAULT_TENANT = "DEFAULT_TENANT";
     public static final TimeValue DEFAULT_GLOBAL_RESOURCE_CACHE_TTL = TimeValue.timeValueMillis(5 * 60 * 1000);
     protected static final Map<String, Tuple<GetDataObjectResponse, Long>> GLOBAL_RESOURCES_CACHE = new ConcurrentHashMap<>();
     protected static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();

--- a/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClient.java
+++ b/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClient.java
@@ -448,9 +448,7 @@ public class DDBOpenSearchClient extends AbstractSdkClient {
         }).exceptionally(t -> {
             log.error("Failed to check the resource type, aborting the update", t);
             Throwable cause = t.getCause() != null ? t.getCause() : t;
-            if (cause instanceof OpenSearchStatusException) {
-                throw (OpenSearchStatusException) cause;
-            } else if (cause instanceof RuntimeException) {
+            if (cause instanceof RuntimeException) {
                 throw (RuntimeException) cause;
             } else {
                 throw new CompletionException("Failed to get the item.", cause);

--- a/ddb-client/src/test/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClientTests.java
+++ b/ddb-client/src/test/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClientTests.java
@@ -87,7 +87,6 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
 import static org.opensearch.core.xcontent.XContentParserUtils.ensureExpectedToken;
-import static org.opensearch.remote.metadata.client.AbstractSdkClient.DEFAULT_TENANT;
 import static org.opensearch.remote.metadata.client.impl.DDBOpenSearchClient.simulateOpenSearchResponse;
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_GLOBAL_RESOURCE_CACHE_TTL_KEY;
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_GLOBAL_TENANT_ID_KEY;
@@ -379,7 +378,7 @@ public class DDBOpenSearchClientTests {
         verify(dynamoDbAsyncClient).putItem(putItemRequestArgumentCaptor.capture());
 
         PutItemRequest putItemRequest = putItemRequestArgumentCaptor.getValue();
-        assertNotNull(putItemRequest.item().get(RANGE_KEY).s());
+        assertNotNull(putItemRequest.item().get(RANGE_KEY));
         assertNotNull(response.id());
     }
 
@@ -855,7 +854,7 @@ public class DDBOpenSearchClientTests {
         assertEquals(TEST_ID, tenantIdNullRequest.id());
         assertEquals(TEST_INDEX, updateItemRequest2.tableName());
         assertEquals(TEST_ID, updateItemRequest2.key().get(RANGE_KEY).s());
-        assertEquals(DEFAULT_TENANT, updateItemRequest2.key().get(HASH_KEY).s());
+        assertNotNull(updateItemRequest2.key().get(HASH_KEY));
         assertEquals("foo", updateItemRequest2.expressionAttributeValues().get(":source").m().get("data").s());
         assertEquals("old_value", updateItemRequest2.expressionAttributeValues().get(":source").m().get("old_key").s());
 


### PR DESCRIPTION
### Description
This PR fixes the update model failure issue when deploying a global model, the failure doesn't have impact on prediction but it produces an error log when first time the model is been deployed when remote store is DDB. A sample error log seems like this:
```
[2025-11-12T06:37:19,562][ERROR][o.o.m.m.MLModelManager   ] [ip-10-0-137-65.ec2.internal] Failed to update ML model with ID olly2-t2ppl-model-id. Details: java.lang.NullPointerException: Cannot invoke "software.amazon.awssdk.services.dynamodb.model.AttributeValue.m()" because the return value of "java.util.Map.get(Object)" is null
[2025-11-12T06:37:19,562][ERROR][o.o.m.m.MLModelManager   ] [ip-10-0-137-65.ec2.internal] Failed to update the provided ML model
java.lang.NullPointerException: Cannot invoke "software.amazon.awssdk.services.dynamodb.model.AttributeValue.m()" because the return value of "java.util.Map.get(Object)" is null
```
The reason is when updating an item the tenant id is not been updated to global tenant id if it's global resource.

Cluster manager should ensure the `_seq_no` exists in each global resources if the resource is possibly to be updated, since when updating the global resources, either `_seq_no` either comes from updateRequest or from the item source in DDB, since ml-commons doesn't have this value in updateRequest, so the items should have this field.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
