### PR TITLE
[FEATURE]: Add DynamoDB-native search fallback

### DIFF
--- a/core/src/main/java/org/opensearch/remote/metadata/client/SearchDataObjectRequest.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/SearchDataObjectRequest.java
@@ -18,20 +18,41 @@ public class SearchDataObjectRequest {
     private final String[] indices;
     private final String tenantId;
     private final SearchSourceBuilder searchSourceBuilder;
+    private final boolean searchRemoteReplica;
 
     /**
      * Instantiate this request with an optional list of indices and search source
      * <p>
      * For data storage implementations other than OpenSearch, an index may be referred to as a table
+     * Defaults to searching the remote replica.
      *
      * @param indices the indices to search for the object
      * @param tenantId the tenant id
      * @param searchSourceBuilder the search body containing the query
      */
     public SearchDataObjectRequest(String[] indices, String tenantId, SearchSourceBuilder searchSourceBuilder) {
+        this(indices, tenantId, searchSourceBuilder, true);
+    }
+
+    /**
+     * Instantiate this request with an optional list of indices, search source, and remote replica flag.
+     *
+     * @param indices the indices to search for the object
+     * @param tenantId the tenant id
+     * @param searchSourceBuilder the search body containing the query
+     * @param searchRemoteReplica when true (default), delegates search to a remote search-optimized replica
+     *                            (e.g., AOS/AOSS via zero-ETL). When false, searches the primary data store directly.
+     */
+    public SearchDataObjectRequest(
+        String[] indices,
+        String tenantId,
+        SearchSourceBuilder searchSourceBuilder,
+        boolean searchRemoteReplica
+    ) {
         this.indices = indices;
         this.tenantId = tenantId;
         this.searchSourceBuilder = searchSourceBuilder;
+        this.searchRemoteReplica = searchRemoteReplica;
     }
 
     /**
@@ -59,6 +80,14 @@ public class SearchDataObjectRequest {
     }
 
     /**
+     * Returns whether to search the remote replica or the primary data store directly.
+     * @return true if searching the remote replica (default), false for primary store
+     */
+    public boolean searchRemoteReplica() {
+        return this.searchRemoteReplica;
+    }
+
+    /**
      * Instantiate a builder for this object
      * @return a builder instance
      */
@@ -73,6 +102,7 @@ public class SearchDataObjectRequest {
         private String[] indices = null;
         private String tenantId = null;
         private SearchSourceBuilder searchSourceBuilder;
+        private boolean searchRemoteReplica = true;
 
         /**
          * Empty Constructor for the Builder object
@@ -110,11 +140,22 @@ public class SearchDataObjectRequest {
         }
 
         /**
+         * Set whether to search the remote replica or the primary data store directly.
+         * Default is true (existing behavior — delegates to remote replica).
+         * @param searchRemoteReplica false to search primary store directly
+         * @return the updated builder
+         */
+        public Builder searchRemoteReplica(boolean searchRemoteReplica) {
+            this.searchRemoteReplica = searchRemoteReplica;
+            return this;
+        }
+
+        /**
          * Builds the request
          * @return A {@link SearchDataObjectRequest}
          */
         public SearchDataObjectRequest build() {
-            return new SearchDataObjectRequest(this.indices, this.tenantId, this.searchSourceBuilder);
+            return new SearchDataObjectRequest(this.indices, this.tenantId, this.searchSourceBuilder, this.searchRemoteReplica);
         }
     }
 }

--- a/core/src/test/java/org/opensearch/remote/metadata/client/SearchDataObjectRequestTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/SearchDataObjectRequestTests.java
@@ -14,6 +14,8 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SearchDataObjectRequestTests {
 
@@ -39,5 +41,43 @@ public class SearchDataObjectRequestTests {
         assertArrayEquals(testIndices, request.indices());
         assertEquals(testTenantId, request.tenantId());
         assertEquals(testSearchSourceBuilder, request.searchSourceBuilder());
+        assertTrue(request.searchRemoteReplica());
+    }
+
+    @Test
+    public void testSearchRemoteReplicaDefaultTrue() {
+        SearchDataObjectRequest request = SearchDataObjectRequest.builder()
+            .indices(testIndices)
+            .tenantId(testTenantId)
+            .searchSourceBuilder(testSearchSourceBuilder)
+            .build();
+
+        assertTrue(request.searchRemoteReplica());
+    }
+
+    @Test
+    public void testSearchRemoteReplicaFalse() {
+        SearchDataObjectRequest request = SearchDataObjectRequest.builder()
+            .indices(testIndices)
+            .tenantId(testTenantId)
+            .searchSourceBuilder(testSearchSourceBuilder)
+            .searchRemoteReplica(false)
+            .build();
+
+        assertFalse(request.searchRemoteReplica());
+    }
+
+    @Test
+    public void testConstructorDefaultSearchRemoteReplica() {
+        SearchDataObjectRequest request = new SearchDataObjectRequest(testIndices, testTenantId, testSearchSourceBuilder);
+
+        assertTrue(request.searchRemoteReplica());
+    }
+
+    @Test
+    public void testConstructorExplicitSearchRemoteReplica() {
+        SearchDataObjectRequest request = new SearchDataObjectRequest(testIndices, testTenantId, testSearchSourceBuilder, false);
+
+        assertFalse(request.searchRemoteReplica());
     }
 }

--- a/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClient.java
+++ b/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClient.java
@@ -27,6 +27,7 @@ import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
 import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
 import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.sts.StsClient;
@@ -761,7 +762,8 @@ public class DDBOpenSearchClient extends AbstractSdkClient {
 
     /**
      * DDB data needs to be synced with opensearch cluster. {@link RemoteClusterIndicesClient} will then be used to
-     * search data in opensearch cluster.
+     * Searches data. When {@code searchRemoteReplica} is true (default), delegates to the AOS/AOSS
+     * remote collection. When false, queries DynamoDB directly using the tenant partition key.
      *
      * {@inheritDoc}
      */
@@ -771,14 +773,95 @@ public class DDBOpenSearchClient extends AbstractSdkClient {
         Executor executor,
         Boolean isMultiTenancyEnabled
     ) {
-        List<String> indices = Arrays.stream(request.indices()).map(this::getIndexName).collect(Collectors.toList());
+        if (!request.searchRemoteReplica()) {
+            return searchDynamoDb(request);
+        }
 
+        List<String> indices = Arrays.stream(request.indices()).map(this::getIndexName).collect(Collectors.toList());
         SearchDataObjectRequest searchDataObjectRequest = new SearchDataObjectRequest(
             indices.toArray(new String[0]),
             request.tenantId(),
             request.searchSourceBuilder()
         );
         return this.aosOpenSearchClient.searchDataObjectAsync(searchDataObjectRequest, executor, isMultiTenancyEnabled);
+    }
+
+    private CompletionStage<SearchDataObjectResponse> searchDynamoDb(SearchDataObjectRequest request) {
+        final String tenantId = request.tenantId() != null ? request.tenantId() : DEFAULT_TENANT;
+        final String tableName = request.indices()[0];
+        final int size = request.searchSourceBuilder() != null && request.searchSourceBuilder().size() >= 0
+            ? request.searchSourceBuilder().size()
+            : 100;
+        final int from = request.searchSourceBuilder() != null ? request.searchSourceBuilder().from() : 0;
+
+        return doPrivileged(() -> queryAllItems(tableName, tenantId).thenApply(allItems -> {
+            try {
+                int totalHits = allItems.size();
+                int fromIndex = Math.min(from, totalHits);
+                int toIndex = Math.min(fromIndex + size, totalHits);
+                List<Map<String, AttributeValue>> pageItems = allItems.subList(fromIndex, toIndex);
+                String searchResponseJson = simulateSearchResponse(tableName, pageItems, totalHits);
+                return SearchDataObjectResponse.builder().parser(createParser(searchResponseJson)).build();
+            } catch (IOException e) {
+                throw new OpenSearchStatusException("Failed to create search response", RestStatus.INTERNAL_SERVER_ERROR, e);
+            }
+        }));
+    }
+
+    private CompletionStage<List<Map<String, AttributeValue>>> queryAllItems(String tableName, String tenantId) {
+        return queryItemsRecursive(tableName, tenantId, null, new ArrayList<>());
+    }
+
+    private CompletionStage<List<Map<String, AttributeValue>>> queryItemsRecursive(
+        String tableName,
+        String tenantId,
+        Map<String, AttributeValue> exclusiveStartKey,
+        List<Map<String, AttributeValue>> accumulator
+    ) {
+        QueryRequest.Builder builder = QueryRequest.builder()
+            .tableName(tableName)
+            .keyConditionExpression("#hk = :tenantId")
+            .expressionAttributeNames(Map.of("#hk", HASH_KEY))
+            .expressionAttributeValues(Map.of(":tenantId", AttributeValue.builder().s(tenantId).build()));
+        if (exclusiveStartKey != null) {
+            builder.exclusiveStartKey(exclusiveStartKey);
+        }
+        return dynamoDbAsyncClient.query(builder.build()).thenCompose(response -> {
+            accumulator.addAll(response.items());
+            if (response.hasLastEvaluatedKey() && !response.lastEvaluatedKey().isEmpty()) {
+                return queryItemsRecursive(tableName, tenantId, response.lastEvaluatedKey(), accumulator);
+            }
+            return CompletableFuture.completedFuture(accumulator);
+        });
+    }
+
+    static String simulateSearchResponse(String index, List<Map<String, AttributeValue>> items, int totalHits)
+        throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        List<Map<String, Object>> hits = new ArrayList<>();
+        for (Map<String, AttributeValue> item : items) {
+            Map<String, Object> hit = new LinkedHashMap<>();
+            hit.put("_index", index);
+            hit.put("_id", item.containsKey(RANGE_KEY) ? item.get(RANGE_KEY).s() : "");
+            hit.put("_score", 1.0);
+            if (item.containsKey(SOURCE)) {
+                hit.put("_source", DDBJsonTransformer.convertDDBAttributeValueMapToObjectNode(item.get(SOURCE).m()));
+            }
+            hits.add(hit);
+        }
+        Map<String, Object> response = new LinkedHashMap<>();
+        Map<String, Object> hitsWrapper = new LinkedHashMap<>();
+        Map<String, Object> total = new LinkedHashMap<>();
+        total.put("value", totalHits);
+        total.put("relation", "eq");
+        hitsWrapper.put("total", total);
+        hitsWrapper.put("max_score", 1.0);
+        hitsWrapper.put("hits", hits);
+        response.put("took", 0);
+        response.put("timed_out", false);
+        response.put("_shards", Map.of("total", 1, "successful", 1, "skipped", 0, "failed", 0));
+        response.put("hits", hitsWrapper);
+        return mapper.writeValueAsString(response);
     }
 
     private String getIndexName(String index) {

--- a/ddb-client/src/test/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClientTests.java
+++ b/ddb-client/src/test/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClientTests.java
@@ -103,6 +103,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 public class DDBOpenSearchClientTests {
@@ -1299,6 +1300,82 @@ public class DDBOpenSearchClientTests {
         assertEquals(searchDataObjectResponse, searchResponse);
         verify(aosOpenSearchClient).searchDataObjectAsync(searchDataObjectRequestArgumentCaptor.capture(), any(), anyBoolean());
         assertEquals("test_index", searchDataObjectRequestArgumentCaptor.getValue().indices()[0]);
+    }
+
+    @Test
+    public void searchDataObjectAsync_DdbNativeSearch() throws Exception {
+        SearchSourceBuilder searchSourceBuilder = SearchSourceBuilder.searchSource().from(0).size(10);
+        SearchDataObjectRequest searchDataObjectRequest = SearchDataObjectRequest.builder()
+            .indices(TEST_INDEX)
+            .tenantId(TENANT_ID)
+            .searchSourceBuilder(searchSourceBuilder)
+            .searchRemoteReplica(false)
+            .build();
+
+        Map<String, AttributeValue> item = Map.of(
+            "_tenant_id",
+            AttributeValue.builder().s(TENANT_ID).build(),
+            "_id",
+            AttributeValue.builder().s("test-id-1").build(),
+            "_source",
+            AttributeValue.builder()
+                .m(Map.of("config", AttributeValue.builder().m(Map.of("name", AttributeValue.builder().s("test").build())).build()))
+                .build()
+        );
+        software.amazon.awssdk.services.dynamodb.model.QueryResponse queryResponse =
+            software.amazon.awssdk.services.dynamodb.model.QueryResponse.builder().items(item).build();
+        when(dynamoDbAsyncClient.query(any(software.amazon.awssdk.services.dynamodb.model.QueryRequest.class))).thenReturn(
+            CompletableFuture.completedFuture(queryResponse)
+        );
+
+        CompletionStage<SearchDataObjectResponse> searchResponse = sdkClient.searchDataObjectAsync(searchDataObjectRequest);
+        SearchDataObjectResponse response = searchResponse.toCompletableFuture().join();
+
+        assertNotNull(response);
+        verify(dynamoDbAsyncClient).query(any(software.amazon.awssdk.services.dynamodb.model.QueryRequest.class));
+        verifyNoInteractions(aosOpenSearchClient);
+    }
+
+    @Test
+    public void searchDataObjectAsync_DdbNativeSearch_EmptyResult() throws Exception {
+        SearchSourceBuilder searchSourceBuilder = SearchSourceBuilder.searchSource().from(0).size(10);
+        SearchDataObjectRequest searchDataObjectRequest = SearchDataObjectRequest.builder()
+            .indices(TEST_INDEX)
+            .tenantId(TENANT_ID)
+            .searchSourceBuilder(searchSourceBuilder)
+            .searchRemoteReplica(false)
+            .build();
+
+        software.amazon.awssdk.services.dynamodb.model.QueryResponse queryResponse =
+            software.amazon.awssdk.services.dynamodb.model.QueryResponse.builder().items(Collections.emptyList()).build();
+        when(dynamoDbAsyncClient.query(any(software.amazon.awssdk.services.dynamodb.model.QueryRequest.class))).thenReturn(
+            CompletableFuture.completedFuture(queryResponse)
+        );
+
+        CompletionStage<SearchDataObjectResponse> searchResponse = sdkClient.searchDataObjectAsync(searchDataObjectRequest);
+        SearchDataObjectResponse response = searchResponse.toCompletableFuture().join();
+
+        assertNotNull(response);
+        verifyNoInteractions(aosOpenSearchClient);
+    }
+
+    @Test
+    public void searchDataObjectAsync_RemoteReplicaTrue_DelegatesToAos() {
+        SearchSourceBuilder searchSourceBuilder = SearchSourceBuilder.searchSource();
+        SearchDataObjectRequest searchDataObjectRequest = SearchDataObjectRequest.builder()
+            .indices(TEST_INDEX)
+            .tenantId(TENANT_ID)
+            .searchSourceBuilder(searchSourceBuilder)
+            .searchRemoteReplica(true)
+            .build();
+        @SuppressWarnings("unchecked")
+        CompletionStage<SearchDataObjectResponse> searchDataObjectResponse = mock(CompletionStage.class);
+        when(aosOpenSearchClient.searchDataObjectAsync(any(), any(), anyBoolean())).thenReturn(searchDataObjectResponse);
+
+        CompletionStage<SearchDataObjectResponse> searchResponse = sdkClient.searchDataObjectAsync(searchDataObjectRequest);
+
+        assertEquals(searchDataObjectResponse, searchResponse);
+        verify(aosOpenSearchClient).searchDataObjectAsync(any(), any(), anyBoolean());
     }
 
     private Map<String, AttributeValue> getComplexDataSource() {


### PR DESCRIPTION
### Description
Problem: The DDB client currently delegates all search operations to a remote OpenSearch collection via zero-ETL. Plugins with simple query patterns (e.g., listing all items per tenant) cannot perform search 
without a configured remote collection.

### Changes
Adds a `searchRemoteReplica` flag to SearchDataObjectRequest that allows plugins to search the primary DynamoDB store directly instead of requiring a remote AOS/AOSS collection.

- `SearchDataObjectRequest` : added `searchRemoteReplica` field (default true), backward-compatible.
- `DDBOpenSearchClient` (`ddb-client`): routes search based on flag — DDB Query when false, AOS delegation when true
- Added unit tests

### Backward Compatibility
Fully backward compatible. Existing callers are unaffected — the default `searchRemoteReplica(true)` preserves current behavior. Only callers that explicitly opt in with `searchRemoteReplica(false)` use the new DDB-
native path.

### Issues Resolved
https://github.com/opensearch-project/opensearch-remote-metadata-sdk/issues/336

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
