### PR TITLE
Add routing support to SDK request types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 ## [Unreleased 3.x](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/compare/3.5...HEAD)
 ### Features
+- Add routing support to SDK request types ([#351](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/351))
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure

--- a/core/src/main/java/org/opensearch/remote/metadata/client/DataObjectRequest.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/DataObjectRequest.java
@@ -8,6 +8,8 @@
  */
 package org.opensearch.remote.metadata.client;
 
+import org.opensearch.common.Nullable;
+
 /**
  * A superclass for common fields in Data Object Request classes
  */
@@ -18,6 +20,7 @@ public abstract class DataObjectRequest {
     private String tenantId;
     private final String cmkRoleArn;
     private final String assumeRoleArn;
+    private final @Nullable String routing;
 
     /**
      * Instantiate this request with an index and id.
@@ -28,24 +31,22 @@ public abstract class DataObjectRequest {
      * @param tenantId the tenant id
      */
     protected DataObjectRequest(String index, String id, String tenantId) {
-        this(index, id, tenantId, null, null);
+        this(index, id, tenantId, null, null, null);
     }
 
     /**
      * Overloaded constructor allowing optional CMK role ARN.
-     * Existing subclasses can continue using the 3-arg constructor.
      * @param index the index location to delete the object
      * @param id the document id
      * @param tenantId the tenant id
      * @param cmkRoleArn optional CMK role ARN (nullable)
      */
     protected DataObjectRequest(String index, String id, String tenantId, String cmkRoleArn) {
-        this(index, id, tenantId, cmkRoleArn, null);
+        this(index, id, tenantId, cmkRoleArn, null, null);
     }
 
     /**
-     * Overloaded constructor allowing optional CMK role ARN.
-     * Existing subclasses can continue using the 3-arg constructor.
+     * Overloaded constructor allowing optional CMK role ARN and assume role ARN.
      * @param index the index location to delete the object
      * @param id the document id
      * @param tenantId the tenant id
@@ -53,11 +54,32 @@ public abstract class DataObjectRequest {
      * @param assumeRoleArn optional role ARN to assume (nullable)
      */
     protected DataObjectRequest(String index, String id, String tenantId, String cmkRoleArn, String assumeRoleArn) {
+        this(index, id, tenantId, cmkRoleArn, assumeRoleArn, null);
+    }
+
+    /**
+     * Overloaded constructor with all fields including routing.
+     * @param index the index location to delete the object
+     * @param id the document id
+     * @param tenantId the tenant id
+     * @param cmkRoleArn optional CMK role ARN (nullable)
+     * @param assumeRoleArn optional role ARN to assume (nullable)
+     * @param routing optional routing value for shard selection (nullable)
+     */
+    protected DataObjectRequest(
+        String index,
+        String id,
+        String tenantId,
+        String cmkRoleArn,
+        String assumeRoleArn,
+        @Nullable String routing
+    ) {
         this.index = index;
         this.id = id;
         this.tenantId = tenantId;
         this.cmkRoleArn = cmkRoleArn;
         this.assumeRoleArn = assumeRoleArn;
+        this.routing = routing;
     }
 
     /**
@@ -117,6 +139,14 @@ public abstract class DataObjectRequest {
     }
 
     /**
+     * Returns the routing value for shard selection. May not be applicable on all clients.
+     * @return the routing value or null if not set
+     */
+    public @Nullable String routing() {
+        return this.routing;
+    }
+
+    /**
      * Returns whether the subclass can be used in a {@link BulkDataObjectRequest}
      * @return whether the subclass is a write request
      */
@@ -133,6 +163,7 @@ public abstract class DataObjectRequest {
         protected String tenantId = null;
         protected String cmkRoleArn = null;
         protected String assumeRoleArn = null;
+        protected String routing = null;
 
         /**
          * Empty constructor to initialize
@@ -186,6 +217,16 @@ public abstract class DataObjectRequest {
          */
         public T assumeRoleArn(String assumeRoleArn) {
             this.assumeRoleArn = assumeRoleArn;
+            return self();
+        }
+
+        /**
+         * Add a routing value for shard selection. May not be applicable on all clients.
+         * @param routing the routing value
+         * @return the updated builder
+         */
+        public T routing(String routing) {
+            this.routing = routing;
             return self();
         }
 

--- a/core/src/main/java/org/opensearch/remote/metadata/client/DeleteDataObjectRequest.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/DeleteDataObjectRequest.java
@@ -37,7 +37,31 @@ public class DeleteDataObjectRequest extends WriteDataObjectRequest<DeleteDataOb
         RefreshPolicy refreshPolicy,
         TimeValue timeout
     ) {
-        super(index, id, tenantId, ifSeqNo, ifPrimaryTerm, refreshPolicy, timeout, false, null, null);
+        this(index, id, tenantId, ifSeqNo, ifPrimaryTerm, refreshPolicy, timeout, null);
+    }
+
+    /**
+     * Overloaded constructor with routing support.
+     * @param index the index location
+     * @param id the document id
+     * @param tenantId the tenant id
+     * @param ifSeqNo the sequence number to match or null if not required
+     * @param ifPrimaryTerm the primary term to match or null if not required
+     * @param refreshPolicy when should the written data be refreshed
+     * @param timeout A timeout to wait if the index operation can't be performed immediately
+     * @param routing optional routing value for shard selection (nullable)
+     */
+    public DeleteDataObjectRequest(
+        String index,
+        String id,
+        String tenantId,
+        Long ifSeqNo,
+        Long ifPrimaryTerm,
+        RefreshPolicy refreshPolicy,
+        TimeValue timeout,
+        String routing
+    ) {
+        super(index, id, tenantId, ifSeqNo, ifPrimaryTerm, refreshPolicy, timeout, false, null, null, routing);
     }
 
     /**
@@ -59,15 +83,17 @@ public class DeleteDataObjectRequest extends WriteDataObjectRequest<DeleteDataOb
          */
         public DeleteDataObjectRequest build() {
             WriteDataObjectRequest.validateSeqNoAndPrimaryTerm(this.ifSeqNo, this.ifPrimaryTerm, false);
-            return new DeleteDataObjectRequest(
+            DeleteDataObjectRequest request = new DeleteDataObjectRequest(
                 this.index,
                 this.id,
                 this.tenantId,
                 this.ifSeqNo,
                 this.ifPrimaryTerm,
                 this.refreshPolicy,
-                this.timeout
+                this.timeout,
+                this.routing
             );
+            return request;
         }
     }
 }

--- a/core/src/main/java/org/opensearch/remote/metadata/client/GetDataObjectRequest.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/GetDataObjectRequest.java
@@ -36,7 +36,29 @@ public class GetDataObjectRequest extends DataObjectRequest {
         String cmkRoleArn,
         String assumeRoleArn
     ) {
-        super(index, id, tenantId, cmkRoleArn, assumeRoleArn);
+        this(index, id, tenantId, fetchSourceContext, cmkRoleArn, assumeRoleArn, null);
+    }
+
+    /**
+     * Overloaded constructor with routing support.
+     * @param index the index location
+     * @param id the document id
+     * @param tenantId the tenant id
+     * @param fetchSourceContext the context for fetching source
+     * @param cmkRoleArn optional CMK role ARN (nullable)
+     * @param assumeRoleArn optional role ARN to assume (nullable)
+     * @param routing optional routing value for shard selection (nullable)
+     */
+    public GetDataObjectRequest(
+        String index,
+        String id,
+        String tenantId,
+        FetchSourceContext fetchSourceContext,
+        String cmkRoleArn,
+        String assumeRoleArn,
+        String routing
+    ) {
+        super(index, id, tenantId, cmkRoleArn, assumeRoleArn, routing);
         this.fetchSourceContext = fetchSourceContext;
     }
 
@@ -88,7 +110,8 @@ public class GetDataObjectRequest extends DataObjectRequest {
                 this.tenantId,
                 this.fetchSourceContext,
                 this.cmkRoleArn,
-                this.assumeRoleArn
+                this.assumeRoleArn,
+                this.routing
             );
         }
     }

--- a/core/src/main/java/org/opensearch/remote/metadata/client/PutDataObjectRequest.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/PutDataObjectRequest.java
@@ -51,7 +51,52 @@ public class PutDataObjectRequest extends WriteDataObjectRequest<PutDataObjectRe
         String cmkRoleArn,
         String assumeRoleArn
     ) {
-        super(index, id, tenantId, ifSeqNo, ifPrimaryTerm, refreshPolicy, timeout, !overwriteIfExists, cmkRoleArn, assumeRoleArn);
+        this(
+            index,
+            id,
+            tenantId,
+            ifSeqNo,
+            ifPrimaryTerm,
+            refreshPolicy,
+            timeout,
+            overwriteIfExists,
+            dataObject,
+            cmkRoleArn,
+            assumeRoleArn,
+            null
+        );
+    }
+
+    /**
+     * Overloaded constructor with routing support.
+     * @param index the index location
+     * @param id the document id
+     * @param tenantId the tenant id
+     * @param ifSeqNo the sequence number to match or null if not required
+     * @param ifPrimaryTerm the primary term to match or null if not required
+     * @param refreshPolicy when should the written data be refreshed
+     * @param timeout A timeout to wait if the index operation can't be performed immediately
+     * @param overwriteIfExists whether to overwrite the document if it exists
+     * @param dataObject the data object
+     * @param cmkRoleArn the cmk arn role to encrypt/decrypt
+     * @param assumeRoleArn A role to assume for cmk
+     * @param routing optional routing value for shard selection (nullable)
+     */
+    public PutDataObjectRequest(
+        String index,
+        String id,
+        String tenantId,
+        Long ifSeqNo,
+        Long ifPrimaryTerm,
+        RefreshPolicy refreshPolicy,
+        TimeValue timeout,
+        boolean overwriteIfExists,
+        ToXContentObject dataObject,
+        String cmkRoleArn,
+        String assumeRoleArn,
+        String routing
+    ) {
+        super(index, id, tenantId, ifSeqNo, ifPrimaryTerm, refreshPolicy, timeout, !overwriteIfExists, cmkRoleArn, assumeRoleArn, routing);
         this.overwriteIfExists = overwriteIfExists;
         this.dataObject = dataObject;
     }
@@ -128,7 +173,7 @@ public class PutDataObjectRequest extends WriteDataObjectRequest<PutDataObjectRe
                 // createOperation = true when overwriteIfExists is false
                 !this.overwriteIfExists
             );
-            return new PutDataObjectRequest(
+            PutDataObjectRequest request = new PutDataObjectRequest(
                 this.index,
                 this.id,
                 this.tenantId,
@@ -139,8 +184,10 @@ public class PutDataObjectRequest extends WriteDataObjectRequest<PutDataObjectRe
                 this.overwriteIfExists,
                 this.dataObject,
                 this.cmkRoleArn,
-                this.assumeRoleArn
+                this.assumeRoleArn,
+                this.routing
             );
+            return request;
         }
     }
 }

--- a/core/src/main/java/org/opensearch/remote/metadata/client/SearchDataObjectRequest.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/SearchDataObjectRequest.java
@@ -8,6 +8,7 @@
  */
 package org.opensearch.remote.metadata.client;
 
+import org.opensearch.common.Nullable;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
 /**
@@ -18,20 +19,23 @@ public class SearchDataObjectRequest {
     private final String[] indices;
     private final String tenantId;
     private final SearchSourceBuilder searchSourceBuilder;
+    private final @Nullable String routing;
 
     /**
-     * Instantiate this request with an optional list of indices and search source
+     * Instantiate this request with an optional list of indices, search source, and routing.
      * <p>
      * For data storage implementations other than OpenSearch, an index may be referred to as a table
      *
      * @param indices the indices to search for the object
      * @param tenantId the tenant id
      * @param searchSourceBuilder the search body containing the query
+     * @param routing the routing value to control which shard the search hits (nullable)
      */
-    public SearchDataObjectRequest(String[] indices, String tenantId, SearchSourceBuilder searchSourceBuilder) {
+    public SearchDataObjectRequest(String[] indices, String tenantId, SearchSourceBuilder searchSourceBuilder, @Nullable String routing) {
         this.indices = indices;
         this.tenantId = tenantId;
         this.searchSourceBuilder = searchSourceBuilder;
+        this.routing = routing;
     }
 
     /**
@@ -59,6 +63,14 @@ public class SearchDataObjectRequest {
     }
 
     /**
+     * Returns the routing value
+     * @return the routing or null if not set
+     */
+    public @Nullable String routing() {
+        return this.routing;
+    }
+
+    /**
      * Instantiate a builder for this object
      * @return a builder instance
      */
@@ -73,6 +85,7 @@ public class SearchDataObjectRequest {
         private String[] indices = null;
         private String tenantId = null;
         private SearchSourceBuilder searchSourceBuilder;
+        private String routing = null;
 
         /**
          * Empty Constructor for the Builder object
@@ -110,11 +123,21 @@ public class SearchDataObjectRequest {
         }
 
         /**
+         * Add a routing value to this builder
+         * @param routing the routing value
+         * @return the updated builder
+         */
+        public Builder routing(String routing) {
+            this.routing = routing;
+            return this;
+        }
+
+        /**
          * Builds the request
          * @return A {@link SearchDataObjectRequest}
          */
         public SearchDataObjectRequest build() {
-            return new SearchDataObjectRequest(this.indices, this.tenantId, this.searchSourceBuilder);
+            return new SearchDataObjectRequest(this.indices, this.tenantId, this.searchSourceBuilder, this.routing);
         }
     }
 }

--- a/core/src/main/java/org/opensearch/remote/metadata/client/UpdateDataObjectRequest.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/UpdateDataObjectRequest.java
@@ -49,7 +49,35 @@ public class UpdateDataObjectRequest extends WriteDataObjectRequest<UpdateDataOb
         int retryOnConflict,
         ToXContentObject dataObject
     ) {
-        super(index, id, tenantId, ifSeqNo, ifPrimaryTerm, refreshPolicy, timeout, false, null, null);
+        this(index, id, tenantId, ifSeqNo, ifPrimaryTerm, refreshPolicy, timeout, retryOnConflict, dataObject, null);
+    }
+
+    /**
+     * Overloaded constructor with routing support.
+     * @param index the index location
+     * @param id the document id
+     * @param tenantId the tenant id
+     * @param ifSeqNo the sequence number to match or null if not required
+     * @param ifPrimaryTerm the primary term to match or null if not required
+     * @param refreshPolicy when should the written data be refreshed
+     * @param timeout A timeout to wait if the index operation can't be performed immediately
+     * @param retryOnConflict the number of retries on version conflict
+     * @param dataObject the data object
+     * @param routing optional routing value for shard selection (nullable)
+     */
+    public UpdateDataObjectRequest(
+        String index,
+        String id,
+        String tenantId,
+        Long ifSeqNo,
+        Long ifPrimaryTerm,
+        RefreshPolicy refreshPolicy,
+        TimeValue timeout,
+        int retryOnConflict,
+        ToXContentObject dataObject,
+        String routing
+    ) {
+        super(index, id, tenantId, ifSeqNo, ifPrimaryTerm, refreshPolicy, timeout, false, null, null, routing);
         this.retryOnConflict = retryOnConflict;
         this.dataObject = dataObject;
     }
@@ -131,7 +159,7 @@ public class UpdateDataObjectRequest extends WriteDataObjectRequest<UpdateDataOb
          */
         public UpdateDataObjectRequest build() {
             WriteDataObjectRequest.validateSeqNoAndPrimaryTerm(this.ifSeqNo, this.ifPrimaryTerm, false);
-            return new UpdateDataObjectRequest(
+            UpdateDataObjectRequest request = new UpdateDataObjectRequest(
                 this.index,
                 this.id,
                 this.tenantId,
@@ -140,8 +168,10 @@ public class UpdateDataObjectRequest extends WriteDataObjectRequest<UpdateDataOb
                 this.refreshPolicy,
                 this.timeout,
                 this.retryOnConflict,
-                this.dataObject
+                this.dataObject,
+                this.routing
             );
+            return request;
         }
     }
 }

--- a/core/src/main/java/org/opensearch/remote/metadata/client/WriteDataObjectRequest.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/WriteDataObjectRequest.java
@@ -50,7 +50,37 @@ public abstract class WriteDataObjectRequest<R extends WriteDataObjectRequest<R>
         String cmkRoleArn,
         String assumeRoleArn
     ) {
-        super(index, id, tenantId, cmkRoleArn, assumeRoleArn);
+        this(index, id, tenantId, ifSeqNo, ifPrimaryTerm, refreshPolicy, timeout, isCreateOperation, cmkRoleArn, assumeRoleArn, null);
+    }
+
+    /**
+     * Overloaded constructor with routing support.
+     * @param index the index location
+     * @param id the document id
+     * @param tenantId the tenant id
+     * @param ifSeqNo the sequence number to match or null if not required
+     * @param ifPrimaryTerm the primary term to match or null if not required
+     * @param refreshPolicy when should the written data be refreshed
+     * @param timeout A timeout to wait if the index operation can't be performed immediately
+     * @param isCreateOperation whether this can only create a new document and not overwrite one
+     * @param cmkRoleArn the cmk arn role to encrypt/decrypt
+     * @param assumeRoleArn A role to assume for cmk
+     * @param routing optional routing value for shard selection (nullable)
+     */
+    protected WriteDataObjectRequest(
+        String index,
+        String id,
+        String tenantId,
+        Long ifSeqNo,
+        Long ifPrimaryTerm,
+        RefreshPolicy refreshPolicy,
+        TimeValue timeout,
+        boolean isCreateOperation,
+        String cmkRoleArn,
+        String assumeRoleArn,
+        String routing
+    ) {
+        super(index, id, tenantId, cmkRoleArn, assumeRoleArn, routing);
         validateSeqNoAndPrimaryTerm(ifSeqNo, ifPrimaryTerm, isCreateOperation);
         this.ifSeqNo = ifSeqNo;
         this.ifPrimaryTerm = ifPrimaryTerm;

--- a/core/src/main/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClient.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClient.java
@@ -145,6 +145,9 @@ public class LocalClusterIndicesClient extends AbstractSdkClient {
             if (shouldUseId(putDataObjectRequest.id())) {
                 indexRequest.id(putDataObjectRequest.id());
             }
+            if (putDataObjectRequest.routing() != null) {
+                indexRequest.routing(putDataObjectRequest.routing());
+            }
             return setSeqNoAndPrimaryTerm(indexRequest, putDataObjectRequest);
         }
     }
@@ -214,7 +217,11 @@ public class LocalClusterIndicesClient extends AbstractSdkClient {
     }
 
     private GetRequest createGetRequest(GetDataObjectRequest request) {
-        return new GetRequest(request.index(), request.id()).fetchSourceContext(request.fetchSourceContext());
+        GetRequest getRequest = new GetRequest(request.index(), request.id()).fetchSourceContext(request.fetchSourceContext());
+        if (request.routing() != null) {
+            getRequest.routing(request.routing());
+        }
+        return getRequest;
     }
 
     @Override
@@ -278,6 +285,9 @@ public class LocalClusterIndicesClient extends AbstractSdkClient {
             if (updateDataObjectRequest.retryOnConflict() > 0) {
                 updateRequest.retryOnConflict(updateDataObjectRequest.retryOnConflict());
             }
+            if (updateDataObjectRequest.routing() != null) {
+                updateRequest.routing(updateDataObjectRequest.routing());
+            }
             return setSeqNoAndPrimaryTerm(updateRequest, updateDataObjectRequest);
         }
     }
@@ -324,6 +334,9 @@ public class LocalClusterIndicesClient extends AbstractSdkClient {
         DeleteRequest deleteRequest = new DeleteRequest(deleteDataObjectRequest.index(), deleteDataObjectRequest.id()).setRefreshPolicy(
             deleteDataObjectRequest.getRefreshPolicy()
         ).timeout(deleteDataObjectRequest.timeout());
+        if (deleteDataObjectRequest.routing() != null) {
+            deleteRequest.routing(deleteDataObjectRequest.routing());
+        }
         return setSeqNoAndPrimaryTerm(deleteRequest, deleteDataObjectRequest);
     }
 
@@ -396,6 +409,9 @@ public class LocalClusterIndicesClient extends AbstractSdkClient {
         log.info("Searching {}", Arrays.toString(request.indices()));
         return doPrivileged(() -> {
             SearchRequest searchRequest = new SearchRequest(request.indices(), searchSource);
+            if (request.routing() != null) {
+                searchRequest.routing(request.routing());
+            }
             client.search(searchRequest, ActionListener.wrap(searchResponse -> {
                 log.info("Search returned {} hits", searchResponse.getHits().getTotalHits());
                 future.complete(new SearchDataObjectResponse(searchResponse));

--- a/core/src/test/java/org/opensearch/remote/metadata/client/DeleteDataObjectRequestTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/DeleteDataObjectRequestTests.java
@@ -75,4 +75,18 @@ public class DeleteDataObjectRequestTests {
         final DeleteDataObjectRequest.Builder onlyPrimaryTermBuilder = DeleteDataObjectRequest.builder().ifPrimaryTerm(testPrimaryTerm);
         assertThrows(IllegalArgumentException.class, () -> onlyPrimaryTermBuilder.build());
     }
+
+    @Test
+    public void testDeleteDataObjectRequestWithRouting() {
+        String testRouting = "test-routing";
+        DeleteDataObjectRequest request = DeleteDataObjectRequest.builder()
+            .index(testIndex)
+            .id(testId)
+            .tenantId(testTenantId)
+            .routing(testRouting)
+            .build();
+
+        assertEquals(testRouting, request.routing());
+        assertNull(DeleteDataObjectRequest.builder().index(testIndex).id(testId).tenantId(testTenantId).build().routing());
+    }
 }

--- a/core/src/test/java/org/opensearch/remote/metadata/client/GetDataObjectRequestTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/GetDataObjectRequestTests.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 
 public class GetDataObjectRequestTests {
@@ -51,5 +52,19 @@ public class GetDataObjectRequestTests {
         assertEquals(testFetchSourceContext, request.fetchSourceContext());
         assertEquals(testCMKRole, request.cmkRoleArn());
         assertEquals(testAssumeRole, request.assumeRoleArn());
+    }
+
+    @Test
+    public void testGetDataObjectRequestWithRouting() {
+        String testRouting = "test-routing";
+        GetDataObjectRequest request = GetDataObjectRequest.builder()
+            .index(testIndex)
+            .id(testId)
+            .tenantId(testTenantId)
+            .routing(testRouting)
+            .build();
+
+        assertEquals(testRouting, request.routing());
+        assertNull(GetDataObjectRequest.builder().index(testIndex).id(testId).tenantId(testTenantId).build().routing());
     }
 }

--- a/core/src/test/java/org/opensearch/remote/metadata/client/PutDataObjectRequestTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/PutDataObjectRequestTests.java
@@ -85,6 +85,29 @@ public class PutDataObjectRequestTests {
     }
 
     @Test
+    public void testPutDataObjectRequestWithRouting() {
+        String testRouting = "test-routing";
+        PutDataObjectRequest request = PutDataObjectRequest.builder()
+            .index(testIndex)
+            .id(testId)
+            .tenantId(testTenantId)
+            .routing(testRouting)
+            .dataObject(testDataObject)
+            .build();
+
+        assertEquals(testRouting, request.routing());
+
+        // Test null routing by default
+        PutDataObjectRequest requestNoRouting = PutDataObjectRequest.builder()
+            .index(testIndex)
+            .id(testId)
+            .tenantId(testTenantId)
+            .dataObject(testDataObject)
+            .build();
+        assertNull(requestNoRouting.routing());
+    }
+
+    @Test
     public void testPutDataObjectRequestWithMap() throws IOException {
         Map<String, Object> dataObjectMap = Map.of("key1", "value1", "key2", "value2");
 

--- a/core/src/test/java/org/opensearch/remote/metadata/client/SearchDataObjectRequestTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/SearchDataObjectRequestTests.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class SearchDataObjectRequestTests {
 
@@ -29,15 +30,26 @@ public class SearchDataObjectRequestTests {
     }
 
     @Test
-    public void testGetDataObjectRequest() {
+    public void testSearchDataObjectRequest() {
+        String testRouting = "test-routing";
         SearchDataObjectRequest request = SearchDataObjectRequest.builder()
             .indices(testIndices)
             .tenantId(testTenantId)
             .searchSourceBuilder(testSearchSourceBuilder)
+            .routing(testRouting)
             .build();
 
         assertArrayEquals(testIndices, request.indices());
         assertEquals(testTenantId, request.tenantId());
         assertEquals(testSearchSourceBuilder, request.searchSourceBuilder());
+        assertEquals(testRouting, request.routing());
+
+        // Test null routing
+        SearchDataObjectRequest requestNoRouting = SearchDataObjectRequest.builder()
+            .indices(testIndices)
+            .tenantId(testTenantId)
+            .searchSourceBuilder(testSearchSourceBuilder)
+            .build();
+        assertNull(requestNoRouting.routing());
     }
 }

--- a/core/src/test/java/org/opensearch/remote/metadata/client/UpdateDataObjectRequestTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/UpdateDataObjectRequestTests.java
@@ -118,4 +118,27 @@ public class UpdateDataObjectRequestTests {
         final Builder onlyPrimaryTermBuilder = UpdateDataObjectRequest.builder().ifPrimaryTerm(testPrimaryTerm);
         assertThrows(IllegalArgumentException.class, () -> onlyPrimaryTermBuilder.build());
     }
+
+    @Test
+    public void testUpdateDataObjectRequestWithRouting() {
+        String testRouting = "test-routing";
+        UpdateDataObjectRequest request = UpdateDataObjectRequest.builder()
+            .index(testIndex)
+            .id(testId)
+            .tenantId(testTenantId)
+            .routing(testRouting)
+            .dataObject(testDataObject)
+            .build();
+
+        assertEquals(testRouting, request.routing());
+        assertNull(
+            UpdateDataObjectRequest.builder()
+                .index(testIndex)
+                .id(testId)
+                .tenantId(testTenantId)
+                .dataObject(testDataObject)
+                .build()
+                .routing()
+        );
+    }
 }

--- a/core/src/test/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClientTests.java
+++ b/core/src/test/java/org/opensearch/remote/metadata/client/impl/LocalClusterIndicesClientTests.java
@@ -193,6 +193,31 @@ public class LocalClusterIndicesClientTests {
     }
 
     @Test
+    public void testPutDataObjectWithRouting() throws IOException {
+        String testRouting = "test-monitor-id";
+        PutDataObjectRequest putRequest = PutDataObjectRequest.builder()
+            .index(TEST_INDEX)
+            .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
+            .routing(testRouting)
+            .dataObject(testDataObject)
+            .build();
+
+        IndexResponse indexResponse = new IndexResponse(new ShardId(TEST_INDEX, "_na_", 0), TEST_ID, 1, 0, 2, true);
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(1);
+            listener.onResponse(indexResponse);
+            return null;
+        }).when(mockedClient).index(any(IndexRequest.class), any());
+
+        sdkClient.putDataObjectAsync(putRequest).toCompletableFuture().join();
+
+        ArgumentCaptor<IndexRequest> requestCaptor = ArgumentCaptor.forClass(IndexRequest.class);
+        verify(mockedClient, times(1)).index(requestCaptor.capture(), any());
+        assertEquals(testRouting, requestCaptor.getValue().routing());
+    }
+
+    @Test
     public void testPutDataObject_Exception() throws IOException {
         PutDataObjectRequest putRequest = PutDataObjectRequest.builder()
             .index(TEST_INDEX)
@@ -345,6 +370,32 @@ public class LocalClusterIndicesClientTests {
     }
 
     @Test
+    public void testGetDataObjectWithRouting() throws IOException {
+        String testRouting = "test-monitor-id";
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder()
+            .index(TEST_INDEX)
+            .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
+            .routing(testRouting)
+            .build();
+
+        String json = testDataObject.toJson();
+        GetResponse getResponse = new GetResponse(new GetResult(TEST_INDEX, TEST_ID, -2, 0, 1, true, new BytesArray(json), null, null));
+
+        doAnswer(invocation -> {
+            ActionListener<GetResponse> listener = invocation.getArgument(1);
+            listener.onResponse(getResponse);
+            return null;
+        }).when(mockedClient).get(any(GetRequest.class), any());
+
+        sdkClient.getDataObjectAsync(getRequest).toCompletableFuture().join();
+
+        ArgumentCaptor<GetRequest> requestCaptor = ArgumentCaptor.forClass(GetRequest.class);
+        verify(mockedClient, times(1)).get(requestCaptor.capture(), any());
+        assertEquals(testRouting, requestCaptor.getValue().routing());
+    }
+
+    @Test
     public void testGetDataObject_Exception() throws IOException {
         GetDataObjectRequest getRequest = GetDataObjectRequest.builder().index(TEST_INDEX).id(TEST_ID).tenantId(TEST_TENANT_ID).build();
 
@@ -491,6 +542,40 @@ public class LocalClusterIndicesClientTests {
     }
 
     @Test
+    public void testUpdateDataObjectWithRouting() throws IOException {
+        String testRouting = "test-monitor-id";
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest.builder()
+            .index(TEST_INDEX)
+            .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
+            .routing(testRouting)
+            .dataObject(testDataObject)
+            .build();
+
+        UpdateResponse updateResponse = new UpdateResponse(
+            new ShardInfo(1, 1),
+            new ShardId(TEST_INDEX, "_na_", 0),
+            TEST_ID,
+            1,
+            0,
+            2,
+            DocWriteResponse.Result.UPDATED
+        );
+
+        doAnswer(invocation -> {
+            ActionListener<UpdateResponse> listener = invocation.getArgument(1);
+            listener.onResponse(updateResponse);
+            return null;
+        }).when(mockedClient).update(any(UpdateRequest.class), any());
+
+        sdkClient.updateDataObjectAsync(updateRequest).toCompletableFuture().join();
+
+        ArgumentCaptor<UpdateRequest> requestCaptor = ArgumentCaptor.forClass(UpdateRequest.class);
+        verify(mockedClient, times(1)).update(requestCaptor.capture(), any());
+        assertEquals(testRouting, requestCaptor.getValue().routing());
+    }
+
+    @Test
     public void testUpdateDataObject_Exception() throws IOException {
         UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest.builder()
             .index(TEST_INDEX)
@@ -596,6 +681,30 @@ public class LocalClusterIndicesClientTests {
     }
 
     @Test
+    public void testDeleteDataObjectWithRouting() throws IOException {
+        String testRouting = "test-monitor-id";
+        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder()
+            .index(TEST_INDEX)
+            .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
+            .routing(testRouting)
+            .build();
+
+        DeleteResponse deleteResponse = new DeleteResponse(new ShardId(TEST_INDEX, "_na_", 0), TEST_ID, 1, 0, 2, true);
+
+        doAnswer(invocation -> {
+            ActionListener<DeleteResponse> listener = invocation.getArgument(1);
+            listener.onResponse(deleteResponse);
+            return null;
+        }).when(mockedClient).delete(any(DeleteRequest.class), any());
+
+        sdkClient.deleteDataObjectAsync(deleteRequest).toCompletableFuture().join();
+
+        ArgumentCaptor<DeleteRequest> requestCaptor = ArgumentCaptor.forClass(DeleteRequest.class);
+        verify(mockedClient, times(1)).delete(requestCaptor.capture(), any());
+        assertEquals(testRouting, requestCaptor.getValue().routing());
+    }
+
     public void testDeleteDataObject_Exception() throws IOException {
         DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder()
             .index(TEST_INDEX)
@@ -983,6 +1092,45 @@ public class LocalClusterIndicesClientTests {
         assertEquals(OpenSearchStatusException.class, cause.getClass());
         assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ((OpenSearchStatusException) cause).status());
         assertEquals("Failed to search indices [test_index]", cause.getMessage());
+    }
+
+    @Test
+    public void testSearchDataObjectWithRouting() throws IOException {
+        String testRouting = "test-monitor-id";
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        SearchDataObjectRequest searchRequest = SearchDataObjectRequest.builder()
+            .indices(TEST_INDEX)
+            .tenantId(TEST_TENANT_ID)
+            .searchSourceBuilder(searchSourceBuilder)
+            .routing(testRouting)
+            .build();
+
+        SearchResponse searchResponse = new SearchResponse(
+            InternalSearchResponse.empty(),
+            null,
+            1,
+            1,
+            0,
+            123,
+            new SearchResponse.PhaseTook(
+                EnumSet.allOf(SearchPhaseName.class).stream().collect(Collectors.toMap(SearchPhaseName::getName, e -> (long) e.ordinal()))
+            ),
+            new ShardSearchFailure[0],
+            SearchResponse.Clusters.EMPTY,
+            null
+        );
+
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(searchResponse);
+            return null;
+        }).when(mockedClient).search(any(SearchRequest.class), any());
+
+        SearchDataObjectResponse response = sdkClient.searchDataObjectAsync(searchRequest).toCompletableFuture().join();
+
+        ArgumentCaptor<SearchRequest> requestCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+        verify(mockedClient, times(1)).search(requestCaptor.capture(), any());
+        assertEquals(testRouting, requestCaptor.getValue().routing());
     }
 
     @Test

--- a/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClient.java
+++ b/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClient.java
@@ -776,7 +776,8 @@ public class DDBOpenSearchClient extends AbstractSdkClient {
         SearchDataObjectRequest searchDataObjectRequest = new SearchDataObjectRequest(
             indices.toArray(new String[0]),
             request.tenantId(),
-            request.searchSourceBuilder()
+            request.searchSourceBuilder(),
+            request.routing()
         );
         return this.aosOpenSearchClient.searchDataObjectAsync(searchDataObjectRequest, executor, isMultiTenancyEnabled);
     }

--- a/remote-client/src/main/java/org/opensearch/remote/metadata/client/impl/RemoteClusterIndicesClient.java
+++ b/remote-client/src/main/java/org/opensearch/remote/metadata/client/impl/RemoteClusterIndicesClient.java
@@ -179,6 +179,9 @@ public class RemoteClusterIndicesClient extends AbstractSdkClient {
                 if (request.ifPrimaryTerm() != null) {
                     builder.ifPrimaryTerm(request.ifPrimaryTerm());
                 }
+                if (request.routing() != null) {
+                    builder.routing(request.routing());
+                }
                 IndexRequest<?> indexRequest = builder.build();
                 log.info("Indexing data object in {}", request.index());
 
@@ -271,7 +274,11 @@ public class RemoteClusterIndicesClient extends AbstractSdkClient {
     ) {
         return doPrivileged(() -> {
             try {
-                GetRequest getRequest = new GetRequest.Builder().index(request.index()).id(request.id()).build();
+                GetRequest.Builder getBuilder = new GetRequest.Builder().index(request.index()).id(request.id());
+                if (request.routing() != null) {
+                    getBuilder.routing(request.routing());
+                }
+                GetRequest getRequest = getBuilder.build();
                 log.info("Getting {} from {}", request.id(), request.index());
                 return openSearchAsyncClient.get(getRequest, MAP_DOCTYPE).thenApply(getResponse -> {
                     log.info("Get found status for id {}: {}", getResponse.id(), getResponse.found());
@@ -339,6 +346,9 @@ public class RemoteClusterIndicesClient extends AbstractSdkClient {
                 if (request.retryOnConflict() > 0) {
                     updateRequestBuilder.retryOnConflict(request.retryOnConflict());
                 }
+                if (request.routing() != null) {
+                    updateRequestBuilder.routing(request.routing());
+                }
                 UpdateRequest<Map<String, Object>, ?> updateRequest = updateRequestBuilder.build();
                 log.info("Updating {} in {}", request.id(), request.index());
                 return openSearchAsyncClient.update(updateRequest, MAP_DOCTYPE).thenApply(updateResponse -> {
@@ -400,6 +410,9 @@ public class RemoteClusterIndicesClient extends AbstractSdkClient {
                 }
                 if (request.ifPrimaryTerm() != null) {
                     builder.ifPrimaryTerm(request.ifPrimaryTerm());
+                }
+                if (request.routing() != null) {
+                    builder.routing(request.routing());
                 }
                 DeleteRequest deleteRequest = builder.build();
                 log.info("Deleting {} from {}", request.id(), request.index());
@@ -639,6 +652,9 @@ public class RemoteClusterIndicesClient extends AbstractSdkClient {
                     searchRequest = searchRequest.toBuilder().index(Arrays.asList(request.indices())).query(boolQuery.toQuery()).build();
                 } else {
                     searchRequest = searchRequest.toBuilder().index(Arrays.asList(request.indices())).build();
+                }
+                if (request.routing() != null) {
+                    searchRequest = searchRequest.toBuilder().routing(request.routing()).build();
                 }
 
                 return openSearchAsyncClient.search(searchRequest, MAP_DOCTYPE).thenApply(searchResponse -> {

--- a/remote-client/src/test/java/org/opensearch/remote/metadata/client/impl/RemoteClusterIndicesClientTests.java
+++ b/remote-client/src/test/java/org/opensearch/remote/metadata/client/impl/RemoteClusterIndicesClientTests.java
@@ -1202,6 +1202,157 @@ public class RemoteClusterIndicesClientTests {
     }
 
     @Test
+    public void testSearchDataObjectWithRouting() throws IOException {
+        String testRouting = "test-monitor-id";
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        SearchDataObjectRequest searchRequest = SearchDataObjectRequest.builder()
+            .indices(TEST_INDEX)
+            .tenantId(TEST_TENANT_ID)
+            .searchSourceBuilder(searchSourceBuilder)
+            .routing(testRouting)
+            .build();
+
+        TotalHits totalHits = new TotalHits.Builder().value(0).relation(TotalHitsRelation.Eq).build();
+        HitsMetadata<Object> hits = new HitsMetadata.Builder<>().hits(Collections.emptyList()).total(totalHits).build();
+        ShardStatistics shards = new ShardStatistics.Builder().failed(0).successful(1).total(1).build();
+        SearchResponse<?> searchResponse = new SearchResponse.Builder<>().hits(hits).took(1).timedOut(false).shards(shards).build();
+
+        ArgumentCaptor<SearchRequest> getRequestCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+        ArgumentCaptor<Class<Map>> mapClassCaptor = ArgumentCaptor.forClass(Class.class);
+        when(mockedOpenSearchAsyncClient.search(getRequestCaptor.capture(), mapClassCaptor.capture())).thenReturn(
+            CompletableFuture.completedFuture((SearchResponse<Map>) searchResponse)
+        );
+
+        sdkClient.searchDataObjectAsync(searchRequest, testThreadPool.executor(TEST_THREAD_POOL)).toCompletableFuture().join();
+
+        ArgumentCaptor<SearchRequest> requestCaptor = ArgumentCaptor.forClass(SearchRequest.class);
+        verify(mockedOpenSearchAsyncClient, times(1)).search(requestCaptor.capture(), any());
+        assertEquals(testRouting, requestCaptor.getValue().routing());
+    }
+
+    @Test
+    public void testPutDataObjectWithRouting() throws IOException {
+        String testRouting = "test-monitor-id";
+        PutDataObjectRequest putRequest = PutDataObjectRequest.builder()
+            .index(TEST_INDEX)
+            .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
+            .routing(testRouting)
+            .dataObject(testDataObject)
+            .build();
+
+        IndexResponse indexResponse = new IndexResponse.Builder().id(TEST_ID)
+            .index(TEST_INDEX)
+            .primaryTerm(0)
+            .result(Result.Created)
+            .seqNo(0)
+            .shards(new ShardStatistics.Builder().failed(0).successful(1).total(1).build())
+            .version(0)
+            .build();
+
+        ArgumentCaptor<IndexRequest<?>> indexRequestCaptor = ArgumentCaptor.forClass(IndexRequest.class);
+        when(mockedOpenSearchAsyncClient.index(indexRequestCaptor.capture())).thenReturn(CompletableFuture.completedFuture(indexResponse));
+
+        sdkClient.putDataObjectAsync(putRequest, testThreadPool.executor(TEST_THREAD_POOL)).toCompletableFuture().join();
+
+        verify(mockedOpenSearchAsyncClient, times(1)).index(indexRequestCaptor.capture());
+        assertEquals(testRouting, indexRequestCaptor.getValue().routing());
+    }
+
+    @Test
+    public void testGetDataObjectWithRouting() throws IOException {
+        String testRouting = "test-monitor-id";
+        GetDataObjectRequest getRequest = GetDataObjectRequest.builder()
+            .index(TEST_INDEX)
+            .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
+            .routing(testRouting)
+            .build();
+
+        GetResponse<Map> getResponse = new GetResponse.Builder<Map>().index(TEST_INDEX)
+            .id(TEST_ID)
+            .found(true)
+            .source(Map.of("data", "foo"))
+            .primaryTerm(0L)
+            .seqNo(0L)
+            .version(0L)
+            .build();
+
+        ArgumentCaptor<GetRequest> getRequestCaptor = ArgumentCaptor.forClass(GetRequest.class);
+        ArgumentCaptor<Class<Map>> mapClassCaptor = ArgumentCaptor.forClass(Class.class);
+        when(mockedOpenSearchAsyncClient.get(getRequestCaptor.capture(), mapClassCaptor.capture())).thenReturn(
+            CompletableFuture.completedFuture(getResponse)
+        );
+
+        sdkClient.getDataObjectAsync(getRequest, testThreadPool.executor(TEST_THREAD_POOL)).toCompletableFuture().join();
+
+        verify(mockedOpenSearchAsyncClient, times(1)).get(getRequestCaptor.capture(), any());
+        assertEquals(testRouting, getRequestCaptor.getValue().routing());
+    }
+
+    @Test
+    public void testUpdateDataObjectWithRouting() throws IOException {
+        String testRouting = "test-monitor-id";
+        UpdateDataObjectRequest updateRequest = UpdateDataObjectRequest.builder()
+            .index(TEST_INDEX)
+            .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
+            .routing(testRouting)
+            .dataObject(testDataObject)
+            .build();
+
+        UpdateResponse<Map> updateResponse = new UpdateResponse.Builder<Map>().id(TEST_ID)
+            .index(TEST_INDEX)
+            .primaryTerm(0)
+            .result(Result.Updated)
+            .seqNo(0)
+            .shards(new ShardStatistics.Builder().failed(0).successful(1).total(1).build())
+            .version(0)
+            .build();
+
+        ArgumentCaptor<UpdateRequest<Map, Map>> updateRequestCaptor = ArgumentCaptor.forClass(UpdateRequest.class);
+        ArgumentCaptor<Class<Map>> mapClassCaptor = ArgumentCaptor.forClass(Class.class);
+        when(mockedOpenSearchAsyncClient.update(updateRequestCaptor.capture(), mapClassCaptor.capture())).thenReturn(
+            CompletableFuture.completedFuture(updateResponse)
+        );
+
+        sdkClient.updateDataObjectAsync(updateRequest, testThreadPool.executor(TEST_THREAD_POOL)).toCompletableFuture().join();
+
+        verify(mockedOpenSearchAsyncClient, times(1)).update(updateRequestCaptor.capture(), any());
+        assertEquals(testRouting, updateRequestCaptor.getValue().routing());
+    }
+
+    @Test
+    public void testDeleteDataObjectWithRouting() throws IOException {
+        String testRouting = "test-monitor-id";
+        DeleteDataObjectRequest deleteRequest = DeleteDataObjectRequest.builder()
+            .index(TEST_INDEX)
+            .id(TEST_ID)
+            .tenantId(TEST_TENANT_ID)
+            .routing(testRouting)
+            .build();
+
+        DeleteResponse deleteResponse = new DeleteResponse.Builder().id(TEST_ID)
+            .index(TEST_INDEX)
+            .primaryTerm(0)
+            .result(Result.Deleted)
+            .seqNo(0)
+            .shards(new ShardStatistics.Builder().failed(0).successful(1).total(1).build())
+            .version(0)
+            .build();
+
+        ArgumentCaptor<DeleteRequest> deleteRequestCaptor = ArgumentCaptor.forClass(DeleteRequest.class);
+        when(mockedOpenSearchAsyncClient.delete(deleteRequestCaptor.capture())).thenReturn(
+            CompletableFuture.completedFuture(deleteResponse)
+        );
+
+        sdkClient.deleteDataObjectAsync(deleteRequest, testThreadPool.executor(TEST_THREAD_POOL)).toCompletableFuture().join();
+
+        verify(mockedOpenSearchAsyncClient, times(1)).delete(deleteRequestCaptor.capture());
+        assertTrue(deleteRequestCaptor.getValue().routing().contains(testRouting));
+    }
+
+    @Test
     public void testSearchDataObject_Exception() throws IOException {
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         SearchDataObjectRequest searchRequest = SearchDataObjectRequest.builder()


### PR DESCRIPTION
Adds a nullable routing field to DataObjectRequest (inherited by PutDataObjectRequest, UpdateDataObjectRequest, DeleteDataObjectRequest) and SearchDataObjectRequest. LocalClusterIndicesClient passes routing through when building native OpenSearch 
requests.

This unblocks the Alerting plugin migration to SdkClient — alert indices use _routing.required: true and all CRUD operations need a routing parameter. Without routing, LocalClusterIndicesClient creates requests that fail with 
BAD_REQUEST: routing is required.

Backward compatible — routing defaults to null, no behavior change for existing callers. Other backends can ignore routing if not applicable.

Changes:
- DataObjectRequest.java: Added routing field, getter, setter, and builder method
- SearchDataObjectRequest.java: Added routing field, getter, builder method, backward-compatible constructor
- PutDataObjectRequest.java, UpdateDataObjectRequest.java, DeleteDataObjectRequest.java: Pass routing from builder to request
- LocalClusterIndicesClient.java: Pass routing to SearchRequest, IndexRequest, UpdateRequest, DeleteRequest
- Added unit tests for routing in SearchDataObjectRequestTests, PutDataObjectRequestTests, and LocalClusterIndicesClientTests

### Issues Resolved

Unblocks Alerting plugin SDK migration

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
