### PR TITLE
Support Jackson 3.x release line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,4 +11,5 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Infrastructure
 ### Documentation
 ### Maintenance
+- Support Jackson 3.x release line ([#358](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/358))
 ### Refactoring

--- a/build.gradle
+++ b/build.gradle
@@ -100,9 +100,8 @@ subprojects {
         implementation "org.apache.logging.log4j:log4j-core:${versions.log4j}"
 
         implementation("com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}")
-        implementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
-        implementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson_databind}"
-        implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson_databind}"
+        implementation("tools.jackson.core:jackson-databind:${versions.jackson3_databind}")
+        implementation "tools.jackson.core:jackson-core:${versions.jackson3}"
 
         implementation "org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}"
         implementation "org.apache.httpcomponents.core5:httpcore5:${versions.httpcore5}"

--- a/core/src/main/java/org/opensearch/remote/metadata/client/AbstractSdkClient.java
+++ b/core/src/main/java/org/opensearch/remote/metadata/client/AbstractSdkClient.java
@@ -8,10 +8,6 @@
  */
 package org.opensearch.remote.metadata.client;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.get.GetResponse;
 import org.opensearch.common.collect.Tuple;
@@ -32,6 +28,10 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.function.Supplier;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
 
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_ENDPOINT_KEY;
 import static org.opensearch.remote.metadata.common.CommonValue.REMOTE_METADATA_GLOBAL_RESOURCE_CACHE_TTL_KEY;

--- a/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBJsonTransformer.java
+++ b/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBJsonTransformer.java
@@ -8,11 +8,6 @@
  */
 package org.opensearch.remote.metadata.client.impl;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 import java.util.ArrayList;
@@ -20,6 +15,11 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 /**
  * Utility methods for transforming JSON to objects
@@ -37,7 +37,7 @@ public class DDBJsonTransformer {
      */
     public static Map<String, AttributeValue> convertJsonObjectToDDBAttributeMap(JsonNode jsonNode) {
         Map<String, AttributeValue> item = new HashMap<>();
-        Iterator<Map.Entry<String, JsonNode>> fields = jsonNode.fields();
+        Iterator<Map.Entry<String, JsonNode>> fields = jsonNode.properties().iterator();
 
         while (fields.hasNext()) {
             Map.Entry<String, JsonNode> field = fields.next();

--- a/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClient.java
+++ b/ddb-client/src/main/java/org/opensearch/remote/metadata/client/impl/DDBOpenSearchClient.java
@@ -8,11 +8,6 @@
  */
 package org.opensearch.remote.metadata.client.impl;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProviderChain;
 import software.amazon.awssdk.auth.credentials.ContainerCredentialsProvider;
@@ -103,6 +98,11 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ObjectNode;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
@@ -284,7 +284,7 @@ public class DDBOpenSearchClient extends AbstractSdkClient {
                         }
                         throw new CompletionException(e);
                     });
-            } catch (IOException e) {
+            } catch (JacksonException e) {
                 throw new OpenSearchStatusException("Failed to parse data object " + request.id(), RestStatus.BAD_REQUEST, e);
             }
         }));
@@ -480,9 +480,9 @@ public class DDBOpenSearchClient extends AbstractSdkClient {
                         throw new OpenSearchStatusException("Parsing error creating update response", RestStatus.INTERNAL_SERVER_ERROR, e);
                     }
                 });
-            } catch (IOException e) {
+            } catch (JacksonException e) {
                 log.error("Error updating {} in {}: {}", request.id(), request.index(), e.getMessage(), e);
-                // Rethrow unchecked exception on update IOException
+                // Rethrow unchecked exception on update JacksonException
                 throw new OpenSearchStatusException(
                     "Parsing error updating data object " + request.id() + " in index " + request.index(),
                     RestStatus.BAD_REQUEST
@@ -816,7 +816,7 @@ public class DDBOpenSearchClient extends AbstractSdkClient {
         String source,
         Long sequenceNumber,
         Map<String, Object> additionalFields
-    ) throws JsonProcessingException {
+    ) throws JacksonException {
         ObjectMapper mapper = new ObjectMapper();
         Map<String, Object> response = new LinkedHashMap<>();
         response.put("_index", index);

--- a/ddb-client/src/test/java/org/opensearch/remote/metadata/client/impl/DDBJsonTransformerTests.java
+++ b/ddb-client/src/test/java/org/opensearch/remote/metadata/client/impl/DDBJsonTransformerTests.java
@@ -8,11 +8,6 @@
  */
 package org.opensearch.remote.metadata.client.impl;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 import org.opensearch.core.common.Strings;
@@ -26,6 +21,11 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.ObjectNode;
 
 public class DDBJsonTransformerTests extends OpenSearchTestCase {
 

--- a/remote-client/build.gradle
+++ b/remote-client/build.gradle
@@ -8,4 +8,9 @@ dependencies {
     testImplementation testFixtures(project(':opensearch-remote-metadata-sdk-core'))
 
     implementation "org.opensearch.client:opensearch-java:${opensearch_java_version}"
+
+    // Jackson 2.x required by opensearch-java JacksonJsonpMapper until opensearch-java migrates to 3.x
+    implementation("com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}")
+    implementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson_databind}"
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${versions.jackson_databind}"
 }


### PR DESCRIPTION
### Description

Migrate core and ddb-client modules from Jackson 2.x (`com.fasterxml.jackson`) to Jackson 3.x (`tools.jackson`), using OpenSearch version catalog properties (`jackson3`, `jackson3_databind`).

Key changes:
- Update Maven coordinates to `tools.jackson.core` group
- Update Java imports from `com.fasterxml.jackson` to `tools.jackson`
- Replace `JsonNode.fields()` with `properties()` (Jackson 3.x rename per JSTEP-6)
- Replace `JsonProcessingException` with `JacksonException` (now unchecked in 3.x)
- Drop `jackson-datatype-jsr310` from common deps (merged into 3.x databind)
- Keep `jackson-annotations` on 2.x (shared by design between 2.x and 3.x)
- Keep `remote-client` on Jackson 2.x until opensearch-java client migrates ([opensearch-java#1948](https://github.com/opensearch-project/opensearch-java/pull/1948))

### Related Issues

Resolves #357

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).