### PR TITLE
Add daily check for upstream version catalog changes

### DIFF
--- a/.github/workflows/check-version-catalog.yml
+++ b/.github/workflows/check-version-catalog.yml
@@ -1,0 +1,51 @@
+name: Check for upstream version catalog changes
+
+on:
+  schedule:
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+jobs:
+  check-and-publish:
+    if: github.repository == 'opensearch-project/opensearch-remote-metadata-sdk'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for relevant version catalog changes
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Get commits touching versions.toml in the last 25 hours
+          SINCE=$(date -u -d '25 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+          COMMITS=$(gh api "repos/opensearch-project/OpenSearch/commits?path=gradle/libs.versions.toml&since=${SINCE}&per_page=1" --jq 'length')
+
+          if [ "$COMMITS" -eq 0 ]; then
+            echo "No changes to versions.toml in the last 25 hours"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Fetch the file and check if any keys we depend on changed
+          DIFF=$(gh api "repos/opensearch-project/OpenSearch/commits?path=gradle/libs.versions.toml&since=${SINCE}&per_page=5" \
+            --jq '.[].sha' | while read -r sha; do
+              gh api "repos/opensearch-project/OpenSearch/commits/${sha}" \
+                --jq '.files[] | select(.filename == "gradle/libs.versions.toml") | .patch // empty'
+            done)
+
+          # Keys from versions.toml that this repo uses
+          WATCHED_KEYS="httpclient5|httpcore5|jackson_annotations|jackson_databind|log4j|mockito"
+
+          if echo "$DIFF" | grep -qE "^[+-].*(${WATCHED_KEYS})"; then
+            echo "Relevant dependency version changed"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "versions.toml changed but not for our dependencies"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Trigger snapshot publish
+        if: steps.check.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run publish-snapshots.yml --repo opensearch-project/opensearch-remote-metadata-sdk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure
+- Add daily check for upstream version catalog changes ([#359](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/359))
 ### Documentation
 ### Maintenance
 ### Refactoring


### PR DESCRIPTION
### Description

Adds a scheduled GitHub Actions workflow that runs daily at 8am UTC to detect changes in OpenSearch core's `gradle/libs.versions.toml` that affect this repo's dependencies.

**How it works:**
1. Uses the GitHub Commits API `path` filter to check if `gradle/libs.versions.toml` was modified in the last 25 hours (1-hour overlap buffer to avoid missing changes near the cron boundary)
2. If changes are found, fetches the actual diff and checks whether any of the version keys this repo depends on were modified: `httpclient5`, `httpcore5`, `jackson_annotations`, `jackson_databind`, `log4j`, `mockito`
3. If a relevant key changed, triggers the existing `publish-snapshots.yml` workflow to rebuild and publish a new snapshot with the updated transitive dependencies

**Why this matters:**
This repo is at the top of the dependency chain for several plugins. When OpenSearch core bumps a dependency version in the catalog, downstream plugins won't pick up the change until this repo publishes a new snapshot. Without this automation, there's a manual gap that can delay downstream builds.

Also supports `workflow_dispatch` for manual triggering.