### PR TITLE
Add Gradle cache to setup-java steps in CI workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           java-version: 25
           distribution: temurin
+          cache: gradle
       - name: Spotless Check
         run: ./gradlew spotlessCheck
   javadoc:
@@ -33,6 +34,7 @@ jobs:
         with:
           java-version: 25
           distribution: temurin
+          cache: gradle
       - name: Javadoc CheckStyle
         run: ./gradlew checkstyleMain
       - name: Javadoc Check
@@ -62,6 +64,7 @@ jobs:
       with:
         java-version: ${{ matrix.java }}
         distribution: temurin
+        cache: gradle
     - name: Build and Run Tests
       id: step-build-test-linux
       run: |
@@ -116,6 +119,7 @@ jobs:
       with:
         java-version: ${{ matrix.java }}
         distribution: temurin
+        cache: gradle
     - name: Build and Run Tests
       run: |
         ./gradlew build

--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
+          cache: gradle
       - uses: actions/checkout@v6
 
       - name: Load secret

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Enhancements
 ### Bug Fixes
 ### Infrastructure
+- Add Gradle cache to setup-java steps in GitHub Actions workflows ([#364](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/364))
 ### Documentation
 ### Maintenance
 ### Security


### PR DESCRIPTION
### Description

Adds `cache: gradle` to all `actions/setup-java` steps across GitHub Actions workflow files. This enables the [built-in dependency caching](https://github.com/actions/setup-java#caching-packages-dependencies) provided by the setup-java action, which caches Gradle dependencies between workflow runs to reduce build times.

### Changes

- Added `cache: gradle` to all 5 `setup-java` steps across 2 workflow files:
  - `CI.yml` (4 steps: spotless, javadoc, build-linux, build-windows)
  - `publish-snapshots.yml` (1 step)

### Reference

- [actions/setup-java caching documentation](https://github.com/actions/setup-java#caching-packages-dependencies)

### Issues Resolved

N/A

### Check List
- [x] New functionality includes testing
  - N/A (infrastructure-only change, CI runs will validate)
- [x] New functionality has been documented
  - N/A
- [x] Commits are signed per the DCO using `--signoff`