### PR TITLE
Revert "Update dependency software.amazon.cryptography:aws-cryptographic-material-providers to v1.11.1 (#362)"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         aws_sdk_version = '2.30.18'
         junit_version = '5.14.4' // version catalog is 4.x
         junit_platform_version = '1.14.4' // version catalog brings in earlier
-        aws_crypto_material_providers_version = '1.11.1' // version for crypto material provider
+        aws_crypto_material_providers_version = '1.11.0' // version for crypto material provider
         aws_database_encryption_sdk_dynamodb_version = '3.9.0' // version for ddb encrypt
     }
 


### PR DESCRIPTION


This reverts commit cc20193a4eb0471b5d8620442bd265a7b337144b.

### Description

Revert "Update dependency software.amazon.cryptography:aws-cryptographic-material-providers to v1.11.1 (#362)"

### Issues Resolved

Seems like ml is using 1.11.0 as transient dep thus failed to resolve.
This is to quickly unblock the build for now.
Thanks.

```
* What went wrong:
Execution failed for task ':opensearch-ml-plugin:bundlePlugin'.
> Could not resolve all files for configuration ':opensearch-ml-plugin:runtimeClasspath'.
   > Could not resolve software.amazon.cryptography:aws-cryptographic-material-providers:1.11.1.
     Required by:
         project ':opensearch-ml-plugin' > project :opensearch-ml-algorithms > org.opensearch:opensearch-remote-metadata-sdk-ddb-client:3.7.0.0
      > Conflict found for module 'software.amazon.cryptography:aws-cryptographic-material-providers': between versions 1.11.1 and 1.11.0
> There is 1 more failure with an identical cause.
```

https://github.com/opensearch-project/ml-commons/pull/4576/changes#r2738834690


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
