### PR TITLE
Fix CVE-2025-67030: Bump plexus-utils from 3.3.0 to 3.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,4 +11,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 ### Infrastructure
 ### Documentation
 ### Maintenance
+### Security
+- Bump plexus-utils from 3.3.0 to 3.6.1 to address CVE-2025-67030 ([#371](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/371))
 ### Refactoring

--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,7 @@ subprojects {
         resolutionStrategy {
             force "net.bytebuddy:byte-buddy:${versions.bytebuddy}"
             force "net.bytebuddy:byte-buddy-agent:${versions.bytebuddy}"
+            force "org.codehaus.plexus:plexus-utils:3.6.1"
         }
     }
 


### PR DESCRIPTION
### Description
Addresses CVE-2025-67030 by forcing plexus-utils to 3.6.1 via resolutionStrategy.

### Issues Resolved
- CVE-2025-67030: plexus-utils <3.6.1 directory traversal in `extractFile` ([advisory](https://nvd.nist.gov/vuln/detail/CVE-2025-67030))

### Remediation Details
| CVE | Package | Old Version | New Version | Method |
|-----|---------|-------------|-------------|--------|
| CVE-2025-67030 | org.codehaus.plexus:plexus-utils | 3.3.0 | 3.6.1 | resolutionStrategy.force |

Note: plexus-utils is a transitive dependency of the checkstyle configuration (via doxia). It is **not** in the runtime classpath — this is a build-time only dependency.

### Testing
- [x] `./gradlew build` completes successfully (60 tests pass)
- [x] No new dependency conflicts introduced
- [x] Verified forced version resolves in dependency tree

### Risk
Low — build-time only dependency, not shipped in plugin artifact.