### PR TITLE
Revert "Add Gradle cache to setup-java steps in CI workflows (#364)"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,6 @@ jobs:
         with:
           java-version: 25
           distribution: temurin
-          cache: gradle
       - name: Spotless Check
         run: ./gradlew spotlessCheck
   javadoc:
@@ -34,7 +33,6 @@ jobs:
         with:
           java-version: 25
           distribution: temurin
-          cache: gradle
       - name: Javadoc CheckStyle
         run: ./gradlew checkstyleMain
       - name: Javadoc Check
@@ -64,7 +62,6 @@ jobs:
       with:
         java-version: ${{ matrix.java }}
         distribution: temurin
-        cache: gradle
     - name: Build and Run Tests
       id: step-build-test-linux
       run: |
@@ -119,7 +116,6 @@ jobs:
       with:
         java-version: ${{ matrix.java }}
         distribution: temurin
-        cache: gradle
     - name: Build and Run Tests
       run: |
         ./gradlew build

--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -24,7 +24,6 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-          cache: gradle
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Load secret


### PR DESCRIPTION
This reverts commit d9b77791ebabeea1bd5802899ab0998c7ecb8fed.

Effectively backporting #392

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
