### PR TITLE
Exclude plexus-utils from checkstyle to fix CVE-2025-67030

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,8 @@ allprojects {
         exclude group: 'org.apache.httpcomponents', module: 'httpcore'
         // Fix for CVE-2025-48924
         exclude group: 'org.apache.commons', module: 'commons-lang3'
+        // Fix for CVE-2025-67030
+        exclude group: 'org.codehaus.plexus', module: 'plexus-utils'
     }
 }
 


### PR DESCRIPTION
### Description

Excludes `org.codehaus.plexus:plexus-utils` from the checkstyle configuration to address CVE-2025-67030.

The vulnerable `plexus-utils:3.3.0` is pulled in transitively via checkstyle's dependency on doxia-core. The root project's checkstyle configuration was not covered by the existing `resolutionStrategy.force` (which only applies to `subprojects`), so an exclusion in the `allprojects` `configurations.checkstyle` block is the correct fix.

Checkstyle does not require plexus-utils at runtime — verified that `checkstyleMain` and `checkstyleTest` pass after this change.

### Issues Resolved

Fixes CVE-2025-67030

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using `--signoff`