### PR TITLE
Revert crypto-material-providers to 1.11.0 and exclude bcprov-jdk18on

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
         aws_sdk_version = '2.30.18'
         junit_version = '5.14.4' // version catalog is 4.x
         junit_platform_version = '1.14.4' // version catalog brings in earlier
-        aws_crypto_material_providers_version = '1.11.1' // version for crypto material provider
+        aws_crypto_material_providers_version = '1.11.0' // version for crypto material provider
         aws_database_encryption_sdk_dynamodb_version = '3.9.0' // version for ddb encrypt
     }
 

--- a/ddb-client/build.gradle
+++ b/ddb-client/build.gradle
@@ -12,8 +12,14 @@ dependencies {
     implementation(platform("software.amazon.awssdk:bom:${versions.aws}"))
     implementation("software.amazon.awssdk:kms:${versions.aws}")
     implementation "software.amazon.awssdk:dynamodb"
-    implementation "software.amazon.cryptography:aws-database-encryption-sdk-dynamodb:${rootProject.ext.aws_database_encryption_sdk_dynamodb_version}"
-    implementation "software.amazon.cryptography:aws-cryptographic-material-providers:${rootProject.ext.aws_crypto_material_providers_version}"
+    implementation("software.amazon.cryptography:aws-database-encryption-sdk-dynamodb:${rootProject.ext.aws_database_encryption_sdk_dynamodb_version}") {
+        // OpenSearch 3.x uses bc-fips; exclude non-FIPS bcprov to avoid CVE-2026-5598
+        exclude group: "org.bouncycastle", module: "bcprov-jdk18on"
+    }
+    implementation("software.amazon.cryptography:aws-cryptographic-material-providers:${rootProject.ext.aws_crypto_material_providers_version}") {
+        // OpenSearch 3.x uses bc-fips; exclude non-FIPS bcprov to avoid CVE-2026-5598
+        exclude group: "org.bouncycastle", module: "bcprov-jdk18on"
+    }
     implementation "software.amazon.awssdk:sts:${versions.aws}"
     implementation "software.amazon.awssdk:netty-nio-client:${versions.aws}"
     implementation "io.netty:netty-codec-http:${versions.netty}"


### PR DESCRIPTION
### Description

The recent bump of `aws-cryptographic-material-providers` from 1.11.0 to 1.11.1 (#381) was intended to address CVE-2026-5598 (`bcprov-jdk18on` < 1.84). However, it introduced a version conflict: `aws-database-encryption-sdk-dynamodb:3.9.0` transitively pulls `aws-cryptographic-material-providers:1.11.0`, and the mismatch with 1.11.1 breaks downstream consumers that use `failOnVersionConflict` (e.g., [flow-framework CI](https://github.com/opensearch-project/flow-framework/actions/runs/26833156012)).

The proper fix:
1. **Revert to 1.11.0** — matches the transitive, eliminates the version conflict entirely
2. **Exclude `bcprov-jdk18on`** from both `aws-database-encryption-sdk-dynamodb` and `aws-cryptographic-material-providers` — OpenSearch 3.x uses `bc-fips` and does not need non-FIPS bouncycastle. This properly addresses CVE-2026-5598.

Verified: `bcprov-jdk18on` is completely removed from the `runtimeClasspath`.

### Issues Resolved

- Fixes downstream build failure: https://github.com/opensearch-project/flow-framework/pull/1405
- Addresses CVE-2026-5598 (`bcprov-jdk18on` < 1.84)

### Check List
- [x] New functionality includes testing
  - N/A - build config fix, verified `./gradlew assemble` passes and `bcprov-jdk18on` removed from runtimeClasspath
- [x] New functionality has been documented
  - N/A
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.