### PR TITLE
Force netty and httpclient5 versions to address CVE-2026-33870, CVE-2026-33871, CVE-2026-40542

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,11 @@ subprojects {
             force "net.bytebuddy:byte-buddy:${versions.bytebuddy}"
             force "net.bytebuddy:byte-buddy-agent:${versions.bytebuddy}"
             force "org.codehaus.plexus:plexus-utils:4.0.3"
+            // Fix for CVE-2026-33870 and CVE-2026-33871
+            force "io.netty:netty-codec-http:${versions.netty}"
+            force "io.netty:netty-codec-http2:${versions.netty}"
+            // Fix for CVE-2026-40542
+            force "org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}"
         }
     }
 


### PR DESCRIPTION
### Description

Add resolution strategy force directives to ensure all transitive dependencies resolve to patched versions, preventing dependency scanners from flagging vulnerable transitive pulls.

### CVEs Addressed

| CVE | Component | Issue | Fix Version |
|---|---|---|---|
| CVE-2026-33870 | `io.netty:netty-codec-http` | HTTP Request Smuggling via Chunked Extension Quoted-String Parsing | ≥ 4.1.132.Final / 4.2.10.Final |
| CVE-2026-33871 | `io.netty:netty-codec-http2` | HTTP/2 CONTINUATION Frame Flood DoS via Zero-Byte Frame Bypass | ≥ 4.1.132.Final / 4.2.10.Final |
| CVE-2026-40542 | `httpclient5` | Missing Critical Step in SCRAM-SHA-256 Authentication | ≥ 5.6.1 |

### Changes

Forces resolution of:
- `io.netty:netty-codec-http` and `io.netty:netty-codec-http2` to `${versions.netty}` (currently 4.2.15.Final)
- `org.apache.httpcomponents.client5:httpclient5` to `${versions.httpclient5}` (currently 5.6.1)

The OpenSearch version catalog already provides safe versions, but without explicit force directives, transitive dependencies (e.g., AWS SDK's `netty-nio-client` pulling netty 4.1.124.Final) can be flagged by security scanners.

### Testing

- Full build passes: 106 tests, 0 failures
- Verified dependency tree shows all netty artifacts resolve to 4.2.15.Final
- Verified httpclient5 resolves to 5.6.1 across all modules