### PR TITLE
Fix CVE-2025-67030: exclude vulnerable plexus-utils from checkstyle configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,8 @@ allprojects {
         exclude group: 'org.apache.httpcomponents', module: 'httpcore'
         // Fix for CVE-2025-48924
         exclude group: 'org.apache.commons', module: 'commons-lang3'
+        // Fix for CVE-2025-67030
+        exclude group: 'org.codehaus.plexus', module: 'plexus-utils'
     }
 }
 


### PR DESCRIPTION
## Summary
- Excludes `org.codehaus.plexus:plexus-utils` from the checkstyle configuration to remediate CVE-2025-67030 (GHSA-6fmv-xxpf-w3cw)
- The vulnerable version (3.3.0) is a transitive dependency pulled in via `doxia-core@1.12.0` by checkstyle and is not required at runtime
- Follows the same exclusion pattern already used for other CVE fixes in this block (httpcomponents, commons-lang3)

## CVE Details
- **CVE:** CVE-2025-67030
- **Advisory:** GHSA-6fmv-xxpf-w3cw
- **Severity:** HIGH
- **Affected:** org.codehaus.plexus:plexus-utils < 3.6.1
- **Fixed in:** 3.6.1

## Test plan
- [x] Verified `plexus-utils` no longer appears in checkstyle dependency tree for all subprojects
- [x] Verified project compiles successfully after the change