### PR TITLE
Add ci.opensearch.org/m2/ mirror for plugin resolution (opensearch-remote-metadata-sdk)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ buildscript {
 
     repositories {
         mavenLocal()
+        maven { url = "https://ci.opensearch.org/m2/" }
         maven { url = "https://ci.opensearch.org/maven2/" }
         maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         mavenCentral()
@@ -55,6 +56,7 @@ allprojects {
 
     repositories {
         mavenLocal()
+        maven { url = "https://ci.opensearch.org/m2/" }
         maven { url = "https://ci.opensearch.org/maven2/" }
         maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ buildscript {
 
     repositories {
         mavenLocal()
-        maven { url = "https://ci.opensearch.org/m2/" }
         maven { url = "https://ci.opensearch.org/maven2/" }
+        maven { url = "https://ci.opensearch.org/m2/" }
         maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         mavenCentral()
         maven { url = "https://plugins.gradle.org/m2/" }
@@ -56,8 +56,8 @@ allprojects {
 
     repositories {
         mavenLocal()
-        maven { url = "https://ci.opensearch.org/m2/" }
         maven { url = "https://ci.opensearch.org/maven2/" }
+        maven { url = "https://ci.opensearch.org/m2/" }
         maven { url = "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         mavenCentral()
         maven { url = "https://plugins.gradle.org/m2/" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,8 +9,8 @@
 
 pluginManagement {
     repositories {
-        maven { url = uri("https://ci.opensearch.org/m2/") }
         maven { url = uri("https://ci.opensearch.org/maven2/") }
+        maven { url = uri("https://ci.opensearch.org/m2/") }
         gradlePluginPortal()
         mavenCentral()
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,6 +9,7 @@
 
 pluginManagement {
     repositories {
+        maven { url = uri("https://ci.opensearch.org/m2/") }
         maven { url = uri("https://ci.opensearch.org/maven2/") }
         gradlePluginPortal()
         mavenCentral()


### PR DESCRIPTION
### Description
Add ci.opensearch.org/m2/ mirror for plugin resolution (opensearch-remote-metadata-sdk)

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6278#issuecomment-5135909975

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).