### PR TITLE
Pin checkstyle version to 13.9.0 (opensearch-remote-metadata-sdk)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ allprojects {
     project.getExtensions().getExtraProperties().set("versions", VersionProperties.getVersions())
 
     checkstyle {
-        toolVersion = "latest.release"
+        toolVersion = "13.9.0"
     }
 
     configurations.checkstyle {


### PR DESCRIPTION
### Description
Pin checkstyle version to 13.9.0 (opensearch-remote-metadata-sdk)

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6278#issuecomment-5148963803