### PR TITLE
[Backport 2.19] Add Eclipse P2 mirror to avoid download.eclipse.org outages (opensearch-remote-metadata-sdk)

### DIFF
--- a/formatter/formatting.gradle
+++ b/formatter/formatting.gradle
@@ -20,7 +20,7 @@ spotless {
                 '',
                 '\\#java|\\#org.opensearch|\\#org.hamcrest|\\#'
         )
-        eclipse().configFile rootProject.file('formatter/formatterConfig.xml')
+        eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://ci.opensearch.org/")).configFile rootProject.file('formatter/formatterConfig.xml')
         trimTrailingWhitespace()
         endWithNewline();
 


### PR DESCRIPTION
### Description
Backport of #447 to the `2.19` branch — adds the Eclipse P2 mirror (`https://ci.opensearch.org/`) to the spotless `eclipse()` config to avoid `download.eclipse.org` outages. Only the mirror one-liner is backported.

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6421#issuecomment-5271186726

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).